### PR TITLE
Minor fixes to macOS requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All the requirements are embedded within the installer.
 * In order to use QSV, you must have the `intel-mediasdk` (apt) or `intel-media-sdk` (pacman) package installed.
 
 ### OSX
-* For macOS users, Homebrew has `ffmpeg` `ffprobe` packages.
+* For macOS users, Homebrew has the `ffmpeg` package which includes `ffprobe`. If python 3 was installed with Homebrew, you will also need the `python-tk` package.
 
 ## Downloads
 The installer for Windows is available in the [releases](https://github.com/Kenshin9977/video-dl-script/releases) section.


### PR DESCRIPTION
After testing on my MacBook, I have noticed a few adjustments needed for the requirements:

- FFprobe is included in FFmpeg package, so only installing the `ffmpeg` is needed
- Tkinter is not included in Homebrew's python and must be installed with the `python-tk` package