### PR TITLE
Multiple language support

### DIFF
--- a/ffmpeg_handler.py
+++ b/ffmpeg_handler.py
@@ -8,6 +8,7 @@ import ffmpeg
 import PySimpleGUI as Sg
 
 from gui import gpus_possible_encoders
+from lang import GuiField, get_text
 
 
 def post_process_dl(full_name: str, infos: Dict) -> None:
@@ -30,7 +31,8 @@ def _ffmpeg_video(path: str, acodec_supported: bool, vcodec_supported: bool, fps
     output_path = filename + date_time + ext
     ffmpegCommand = [
         'ffmpeg', '-hide_banner', '-i', path, '-c:a', recode_acodec, '-c:v', recode_vcodec, '-y', output_path]
-    action = "Remuxing" if acodec_supported and vcodec_supported else "Reencoding"
+    action = get_text(GuiField.ff_remux) if acodec_supported and vcodec_supported else get_text(
+        GuiField.ff_reencode)
     _progress_ffmpeg(ffmpegCommand, action, path)
 
 
@@ -41,7 +43,7 @@ def _progress_ffmpeg(cmd: List[str], action: str, filepath: str) -> None:
     layout = [[Sg.Text(action)],
               [Sg.ProgressBar(100, orientation='h',
                               size=(20, 20), key='-PROG-')],
-              [Sg.Text("Starting", key='PROGINFOS1')],
+              [Sg.Text(get_text(GuiField.ff_starting), key='PROGINFOS1')],
               [Sg.Text("", key='PROGINFOS2')],
               [Sg.Cancel()]]
 
@@ -62,7 +64,8 @@ def _progress_ffmpeg(cmd: List[str], action: str, filepath: str) -> None:
             progress_percent = _get_progress_percent(
                 items['time'], total_duration)
             progress_window['PROGINFOS1'].update(f"{progress_percent}%")
-            progress_window['PROGINFOS2'].update(f"Speed: {items['speed']}")
+            progress_window['PROGINFOS2'].update(
+                f"{get_text(GuiField.ff_speed)}: {items['speed']}")
             progress_window['-PROG-'].update(progress_percent)
     progress_window.close()
 

--- a/ffmpeg_handler.py
+++ b/ffmpeg_handler.py
@@ -45,7 +45,7 @@ def _progress_ffmpeg(cmd: List[str], action: str, filepath: str) -> None:
                               size=(20, 20), key='-PROG-')],
               [Sg.Text(get_text(GuiField.ff_starting), key='PROGINFOS1')],
               [Sg.Text("", key='PROGINFOS2')],
-              [Sg.Cancel()]]
+              [Sg.Cancel(button_text=get_text(GuiField.cancel_button))]]
 
     progress_window = Sg.Window(
         action, layout, no_titlebar=True, grab_anywhere=True)

--- a/gui.py
+++ b/gui.py
@@ -7,8 +7,9 @@ from typing import Dict, List
 import GPUtil
 import PySimpleGUI as Sg
 
+from lang import (GuiField, get_available_languages_name,
+                  get_current_language_name, get_text, set_current_language)
 from ytdlp_handler import *
-from lang import get_text, GuiField
 
 
 def _get_encoders_list() -> List[str]:
@@ -33,9 +34,13 @@ def _video_dl() -> None:
     download_path = _get_download_path()
     Sg.theme('DarkGrey13')
     layout = [
-        [Sg.Text(get_text(GuiField.link))],
+        [Sg.Combo(get_available_languages_name(),
+                  default_value=get_current_language_name(),
+                  enable_events=True,
+                  readonly=True, key="Lang")],
+        [Sg.Text(get_text(GuiField.link), key="TextLink")],
         [Sg.Input(key="url")],
-        [Sg.Text(get_text(GuiField.destination))],
+        [Sg.Text(get_text(GuiField.destination), key="TextDestination")],
         [Sg.Input(download_path, key="path"),
          Sg.FolderBrowse(button_text="...")],
         [Sg.Checkbox(get_text(GuiField.start), default=False, checkbox_color="black", enable_events=True, key="Start"),
@@ -56,15 +61,15 @@ def _video_dl() -> None:
          Sg.Text(":", size=(1, 1), pad=(0, 0)),
          Sg.Input(size=(4, 1), disabled=True, disabled_readonly_background_color="gray", key="eS", enable_events=True,
                   default_text="59")],
-        [Sg.Text(get_text(GuiField.quality))],
+        [Sg.Text(get_text(GuiField.quality), key="TextQuality")],
         [Sg.Combo(['4320p', '2160p', '1440p', '1080p', '720p', '480p'],
                   default_value='1080p', readonly=True, key="MaxHeight")],
-        [Sg.Text(get_text(GuiField.framerate))],
+        [Sg.Text(get_text(GuiField.framerate), key="TextFramerate")],
         [Sg.Combo(['60', '30'], default_value='60',
                   readonly=True, key="MaxFPS")],
         [Sg.Checkbox(get_text(GuiField.audio_only), default=False, checkbox_color="black",
                      enable_events=True, key="AudioOnly")],
-        [Sg.Text(get_text(GuiField.cookies))],
+        [Sg.Text(get_text(GuiField.cookies), key="TextCookies")],
         [Sg.Combo(['None', 'Brave', 'Chrome', 'Chromium', 'Edge', 'Firefox', 'Opera', 'Safari', 'Vivaldi'],
                   default_value='None', readonly=True, key="Browser")],
         [Sg.Button(get_text(GuiField.dl_button), enable_events=True, key="dl"),
@@ -84,6 +89,8 @@ def _video_dl() -> None:
             _trim_checkbox(values, window, event)
         elif event == "AudioOnly":
             _audio_only_checkbox(values, window)
+        elif event == "Lang":
+            _change_language(values, window)
         elif event == "dl":
             if values["path"] == '':
                 window["error"].update(
@@ -187,6 +194,32 @@ def _get_download_path() -> str:
         return location
     else:
         return ''
+
+
+def _change_language(values: Dict, window: Sg.Window) -> None:
+    """
+    Updates current language and update the window's text fields.
+    """
+    set_current_language(values["Lang"])
+    _update_text_lang(window)
+
+
+def _update_text_lang(window: Sg.Window) -> None:
+    """
+    Update the text of each element on the layout.
+
+    Note: Checkboxes elements need "text=" to be specified.
+    """
+    window["TextLink"].update(get_text(GuiField.link))
+    window["TextDestination"].update(get_text(GuiField.destination))
+    window["Start"].update(text=get_text(GuiField.start))
+    window["End"].update(text=get_text(GuiField.end))
+    window["TextQuality"].update(get_text(GuiField.quality))
+    window["TextFramerate"].update(get_text(GuiField.framerate))
+    window["AudioOnly"].update(text=get_text(GuiField.audio_only))
+    window["TextCookies"].update(get_text(GuiField.cookies))
+    window["dl"].update(get_text(GuiField.dl_button))
+    return
 
 
 if __name__ == '__main__':

--- a/gui.py
+++ b/gui.py
@@ -8,6 +8,7 @@ import GPUtil
 import PySimpleGUI as Sg
 
 from ytdlp_handler import *
+from lang import get_text, GuiField
 
 
 def _get_encoders_list() -> List[str]:
@@ -32,12 +33,12 @@ def _video_dl() -> None:
     download_path = _get_download_path()
     Sg.theme('DarkGrey13')
     layout = [
-        [Sg.Text("Link")],
+        [Sg.Text(get_text(GuiField.link))],
         [Sg.Input(key="url")],
-        [Sg.Text("Destination folder")],
+        [Sg.Text(get_text(GuiField.destination))],
         [Sg.Input(download_path, key="path"),
          Sg.FolderBrowse(button_text="...")],
-        [Sg.Checkbox("Start", default=False, checkbox_color="black", enable_events=True, key="Start"),
+        [Sg.Checkbox(get_text(GuiField.start), default=False, checkbox_color="black", enable_events=True, key="Start"),
          Sg.Input(size=(4, 1), disabled=True, disabled_readonly_background_color="gray", key="sH", enable_events=True,
                   default_text="00"),
          Sg.Text(":", size=(1, 1), pad=(0, 0)),
@@ -46,7 +47,7 @@ def _video_dl() -> None:
          Sg.Text(":", size=(1, 1), pad=(0, 0)),
          Sg.Input(size=(4, 1), disabled=True, disabled_readonly_background_color="gray", key="sS", enable_events=True,
                   default_text="00")],
-        [Sg.Checkbox("End ", default=False, checkbox_color="black", enable_events=True, key="End"),
+        [Sg.Checkbox(get_text(GuiField.end), default=False, checkbox_color="black", enable_events=True, key="End"),
          Sg.Input(size=(4, 1), disabled=True, disabled_readonly_background_color="gray", key="eH", enable_events=True,
                   default_text="99"),
          Sg.Text(":", size=(1, 1), pad=(0, 0)),
@@ -55,18 +56,18 @@ def _video_dl() -> None:
          Sg.Text(":", size=(1, 1), pad=(0, 0)),
          Sg.Input(size=(4, 1), disabled=True, disabled_readonly_background_color="gray", key="eS", enable_events=True,
                   default_text="59")],
-        [Sg.Text("Maximum quality")],
+        [Sg.Text(get_text(GuiField.quality))],
         [Sg.Combo(['4320p', '2160p', '1440p', '1080p', '720p', '480p'],
                   default_value='1080p', readonly=True, key="MaxHeight")],
-        [Sg.Text("Maximum framerate")],
+        [Sg.Text(get_text(GuiField.framerate))],
         [Sg.Combo(['60', '30'], default_value='60',
                   readonly=True, key="MaxFPS")],
-        [Sg.Checkbox("Audio only", default=False, checkbox_color="black",
+        [Sg.Checkbox(get_text(GuiField.audio_only), default=False, checkbox_color="black",
                      enable_events=True, key="AudioOnly")],
-        [Sg.Text("Use cookies from the selected browser")],
+        [Sg.Text(get_text(GuiField.cookies))],
         [Sg.Combo(['None', 'Brave', 'Chrome', 'Chromium', 'Edge', 'Firefox', 'Opera', 'Safari', 'Vivaldi'],
                   default_value='None', readonly=True, key="Browser")],
-        [Sg.Button("Download", enable_events=True, key="dl"),
+        [Sg.Button(get_text(GuiField.dl_button), enable_events=True, key="dl"),
          Sg.Text(key="error", text_color="red", visible=False)]
     ]
     window = Sg.Window('Video-dl', layout=layout, icon=icon_base64)
@@ -85,7 +86,8 @@ def _video_dl() -> None:
             _audio_only_checkbox(values, window)
         elif event == "dl":
             if values["path"] == '':
-                window["error"].update("Select an output path.", visible=True)
+                window["error"].update(
+                    get_text(GuiField.missing_output), visible=True)
             else:
                 # noinspection PyBroadException
                 try:
@@ -93,18 +95,18 @@ def _video_dl() -> None:
                 except ValueError:
                     logging.error(traceback.format_exc())
                     window["error"].update(
-                        "Download canceled.", visible=True, text_color="yellow")
+                        get_text(GuiField.dl_cancel), visible=True, text_color="yellow")
                 except yt_dlp.utils.DownloadError:
                     logging.error(traceback.format_exc())
                     window["error"].update(
-                        "Unsupported URL.", visible=True, text_color="red")
+                        get_text(GuiField.dl_unsupported_url), visible=True, text_color="red")
                 except Exception:
                     logging.error(traceback.format_exc())
                     window["error"].update(
-                        "An error has occurred.", visible=True, text_color="red")
+                        get_text(GuiField.dl_error), visible=True, text_color="red")
                 else:
                     window["error"].update(
-                        "Download finished.", visible=True, text_color="green")
+                        get_text(GuiField.dl_finish), visible=True, text_color="green")
 
 
 def _audio_only_checkbox(values: Dict, window: Sg.Window) -> None:

--- a/lang.py
+++ b/lang.py
@@ -1,5 +1,6 @@
 import enum
 import locale
+from typing import List
 
 
 class Language(enum.Enum):
@@ -32,16 +33,17 @@ class GuiField(enum.Enum):
     ff_reencode = enum.auto()
     ff_starting = enum.auto()
     ff_speed = enum.auto()
+    cancel_button = enum.auto()
 
 
-global current_language
+global _current_language
 
 
 def _get_language() -> Language:
     """
     Tries to determine the system language, fallbacks to english.
     """
-    global current_language
+    global _current_language
 
     # This dictionary maps the language of a locale to its associated enum
     lang_map = {
@@ -63,7 +65,7 @@ def _get_language() -> Language:
     return Language.english
 
 
-current_language = _get_language()
+_current_language = _get_language()
 
 
 def get_text(field: GuiField) -> str:
@@ -153,13 +155,54 @@ def get_text(field: GuiField) -> str:
             Language.french: "Démarrage",
             Language.german: "Starte"
         },
-        GuiField.ff_speed: { 
-            # Add a space at the end of the message if 
+        GuiField.ff_speed: {
+            # Add a space at the end of the message if
             # the language requires one before a colon
             Language.english: "Speed",
             Language.french: "Vitesse ",
             Language.german: "Geschwindigkeit"
+        },
+        GuiField.cancel_button: {
+            Language.english: "Cancel",
+            Language.french: "Annuler",
+            Language.german: ""
         }
     }
-    global current_language
-    return ui_text[field][current_language]
+    return ui_text[field][_current_language]
+
+
+_available_languages = {
+    Language.english: "English",
+    Language.french: "Français",
+    Language.german: "Deutsch"
+}
+
+_language_from_name = {name: lang for lang,
+                       name in _available_languages.items()}
+
+
+def get_available_languages_name() -> List[str]:
+    """
+    Returns a list of all the available languages in a human-readable form.
+    """
+    return list(_available_languages.values())
+
+
+def get_current_language_name() -> str:
+    """
+    Get the name of the current language.
+    """
+    return _available_languages[_current_language]
+
+
+def set_current_language(name: str) -> None:
+    """
+    Set the current language.
+
+    "name" must be available, else no changes will be made.
+    """
+    if name not in _language_from_name:
+        return
+    global _current_language
+    _current_language = _language_from_name[name]
+    return

--- a/lang.py
+++ b/lang.py
@@ -1,0 +1,145 @@
+import enum
+import locale
+
+
+class Language(enum.Enum):
+    english = enum.auto()
+    french = enum.auto()
+
+
+class GuiField(enum.Enum):
+    # Main window static text
+    link = enum.auto()
+    destination = enum.auto()
+    start = enum.auto()
+    end = enum.auto()
+    quality = enum.auto()
+    framerate = enum.auto()
+    audio_only = enum.auto()
+    cookies = enum.auto()
+    dl_button = enum.auto()
+
+    # Main window status
+    dl_cancel = enum.auto()
+    dl_unsupported_url = enum.auto()
+    dl_error = enum.auto()
+    dl_finish = enum.auto()
+    missing_output = enum.auto()
+
+    # Progress window
+    ff_remux = enum.auto()
+    ff_reencode = enum.auto()
+    ff_starting = enum.auto()
+    ff_speed = enum.auto()
+
+
+global current_language
+
+
+def _get_language() -> Language:
+    """
+    Tries to determine the system language, fallbacks to english.
+    """
+    global current_language
+
+    # This dictionary maps the language of a locale to its associated enum
+    lang_map = {
+        "en": Language.english,
+        "fr": Language.french
+    }
+
+    locale.setlocale(locale.LC_ALL, "")
+    system_language = locale.getdefaultlocale()[0]
+
+    if (system_language is None):
+        return Language.english
+
+    for available_language in lang_map.keys():
+        if(available_language in system_language):
+            return lang_map[available_language]
+
+    return Language.english
+
+
+current_language = _get_language()
+
+
+def get_text(field: GuiField) -> str:
+    ui_text = {
+        GuiField.link: {
+            Language.english: "Link",
+            Language.french: "Lien"
+        },
+        GuiField.destination: {
+            Language.english: "Destination folder",
+            Language.french: "Dossier de destination"
+        },
+        GuiField.start: {
+            Language.english: "Start",
+            Language.french: "Début"
+        },
+        GuiField.end: {
+            Language.english: "End",
+            Language.french: "Fin"
+        },
+        GuiField.quality: {
+            Language.english: "Maximum quality",
+            Language.french: "Qualité maximale"
+        },
+        GuiField.framerate: {
+            Language.english: "Maximum framerate",
+            Language.french: "Nombre d'image par seconde maximum"
+        },
+        GuiField.audio_only: {
+            Language.english: "Audio only",
+            Language.french: "Audio seul"
+        },
+        GuiField.cookies: {
+            Language.english: "Use cookies from the selected browser",
+            Language.french: "Utiliser les cookies du navigateur selectionné"
+        },
+        GuiField.dl_button: {
+            Language.english: "Download",
+            Language.french: "Télécharger"
+        },
+        GuiField.dl_cancel: {
+            Language.english: "Download cancelled.",
+            Language.french: "Téléchargement annulé."
+        },
+        GuiField.dl_unsupported_url: {
+            Language.english: "Unsupported URL.",
+            Language.french: "URL non supportée."
+        },
+        GuiField.dl_error: {
+            Language.english: "An error has occurred.",
+            Language.french: "Une erreur s'est produite."
+        },
+        GuiField.dl_finish: {
+            Language.english: "Download finished.",
+            Language.french: "Téléchargement terminé."
+        },
+        GuiField.missing_output: {
+            Language.english: "Select an output path.",
+            Language.french: "Indiquez un dossier de destination."
+        },
+        GuiField.ff_remux: {
+            Language.english: "Remuxing",
+            Language.french: "Remuxage"
+        },
+        GuiField.ff_reencode: {
+            Language.english: "Re-encoding",
+            Language.french: "Réencodage"
+        },
+        GuiField.ff_starting: {
+            Language.english: "Starting",
+            Language.french: "Démarrage"
+        },
+        GuiField.ff_speed: { 
+            # Add a space at the end of the message if 
+            # the language requires one before a colon
+            Language.english: "Speed",
+            Language.french: "Vitesse "
+        }
+    }
+    global current_language
+    return ui_text[field][current_language]

--- a/lang.py
+++ b/lang.py
@@ -5,6 +5,7 @@ import locale
 class Language(enum.Enum):
     english = enum.auto()
     french = enum.auto()
+    german = enum.auto()
 
 
 class GuiField(enum.Enum):
@@ -45,7 +46,8 @@ def _get_language() -> Language:
     # This dictionary maps the language of a locale to its associated enum
     lang_map = {
         "en": Language.english,
-        "fr": Language.french
+        "fr": Language.french,
+        "de": Language.german
     }
 
     locale.setlocale(locale.LC_ALL, "")
@@ -68,77 +70,95 @@ def get_text(field: GuiField) -> str:
     ui_text = {
         GuiField.link: {
             Language.english: "Link",
-            Language.french: "Lien"
+            Language.french: "Lien",
+            Language.german: "Link"
         },
         GuiField.destination: {
             Language.english: "Destination folder",
-            Language.french: "Dossier de destination"
+            Language.french: "Dossier de destination",
+            Language.german: "Zielordner"
         },
         GuiField.start: {
             Language.english: "Start",
-            Language.french: "Début"
+            Language.french: "Début",
+            Language.german: "Anfang"
         },
         GuiField.end: {
             Language.english: "End",
-            Language.french: "Fin"
+            Language.french: "Fin",
+            Language.german: "Ende"
         },
         GuiField.quality: {
             Language.english: "Maximum quality",
-            Language.french: "Qualité maximale"
+            Language.french: "Qualité maximale",
+            Language.german: "Maximale Qualität"
         },
         GuiField.framerate: {
             Language.english: "Maximum framerate",
-            Language.french: "Nombre d'image par seconde maximum"
+            Language.french: "Nombre d'image par seconde maximum",
+            Language.german: "Maximale Bildfrequenz"
         },
         GuiField.audio_only: {
             Language.english: "Audio only",
-            Language.french: "Audio seul"
+            Language.french: "Audio seul",
+            Language.german: "Nur Audio"
         },
         GuiField.cookies: {
             Language.english: "Use cookies from the selected browser",
-            Language.french: "Utiliser les cookies du navigateur selectionné"
+            Language.french: "Utiliser les cookies du navigateur selectionné",
+            Language.german: "Benutze Cookies des ausgewählten Webbrowsers"
         },
         GuiField.dl_button: {
             Language.english: "Download",
-            Language.french: "Télécharger"
+            Language.french: "Télécharger",
+            Language.german: "Herunterladen"
         },
         GuiField.dl_cancel: {
             Language.english: "Download cancelled.",
-            Language.french: "Téléchargement annulé."
+            Language.french: "Téléchargement annulé.",
+            Language.german: "Herunterladen abgebrochen."
         },
         GuiField.dl_unsupported_url: {
             Language.english: "Unsupported URL.",
-            Language.french: "URL non supportée."
+            Language.french: "URL non supportée.",
+            Language.german: "URL nicht unterstützt."
         },
         GuiField.dl_error: {
             Language.english: "An error has occurred.",
-            Language.french: "Une erreur s'est produite."
+            Language.french: "Une erreur s'est produite.",
+            Language.german: "Ein Fehler ist aufgetreten."
         },
         GuiField.dl_finish: {
             Language.english: "Download finished.",
-            Language.french: "Téléchargement terminé."
+            Language.french: "Téléchargement terminé.",
+            Language.german: "Herunterladen abgeschlossen."
         },
         GuiField.missing_output: {
             Language.english: "Select an output path.",
-            Language.french: "Indiquez un dossier de destination."
+            Language.french: "Indiquez un dossier de destination.",
+            Language.german: "Wähle einen Zielordner."
         },
         GuiField.ff_remux: {
             Language.english: "Remuxing",
-            Language.french: "Remuxage"
+            Language.french: "Remuxage",
+            Language.german: "Remuxen"
         },
         GuiField.ff_reencode: {
             Language.english: "Re-encoding",
-            Language.french: "Réencodage"
+            Language.french: "Réencodage",
+            Language.german: "Neukodierung"
         },
         GuiField.ff_starting: {
             Language.english: "Starting",
-            Language.french: "Démarrage"
+            Language.french: "Démarrage",
+            Language.german: "Starte"
         },
         GuiField.ff_speed: { 
             # Add a space at the end of the message if 
             # the language requires one before a colon
             Language.english: "Speed",
-            Language.french: "Vitesse "
+            Language.french: "Vitesse ",
+            Language.german: "Geschwindigkeit"
         }
     }
     global current_language


### PR DESCRIPTION
## Description

This PR aims to add support for multiple languages that can be changed at runtime.

The following languages are planned to be added:
- [X] French
- [X] German
- [ ] Spanish

All the functionalities are brought by a new module `lang.py` which offers functions to get the current language, change the language, get the localized value of the desired GUI field.

When adding a new language, only the `lang` module needs to be modified as such:
- The new language should be added in the `Language` enum.
- An entry in the `lang_map` should be added where the first two letters of the corresponding locale should be mapped to the new enumeration entry like `"en": Language.english`. This allows for the language to be automatically detected on launch.
- The translation for each field should be added in the ui_text variable.
- An entry should be added in `_available_languages` where the key is the new enumeration entry and the value is the name of language in the language. For example, in French it would be: `Language.french: "Français"`

When adding a new text element in the GUI, the `lang` module should be modified as such:
- The new field should be given a name in the `GuiField` enum.
- An entry in `ui_text` should be added containing a translation for each available language.
- If the text field is part of the main window, add an update entry in the `_update_text_lang` functions (`gui.py`).