### PR TITLE
Fixes for macOS

### DIFF
--- a/gen_new_version.py
+++ b/gen_new_version.py
@@ -164,6 +164,8 @@ def get_name_for_platform() -> str:
         ext = ".exe"
     elif platform == "Linux":
         ext = "_amd64.deb"
+    elif platform == "Darwin":
+        ext = ".dmg"
     if ext is None:
         log.error("Platform isn't supported")
         raise RuntimeError

--- a/updater.py
+++ b/updater.py
@@ -43,9 +43,12 @@ class Updater:
         if self.versions_dict is None:
             log.info("No versions file found")
             return False
-        self.latest_version = self.versions_dict[APP_NAME][self.platform][
-            "latest_version"
-        ]
+        if self.platform in self.versions_dict[APP_NAME]:
+            self.latest_version = self.versions_dict[APP_NAME][self.platform][
+                "latest_version"
+            ]
+        else:
+            self.latest_version = APP_VERSION
         return self.latest_version != APP_VERSION
 
     def _get_versions_json(self) -> None:


### PR DESCRIPTION
This PR addresses the issues for macOS discussed in #7.

It implements both fixes mentioned:
- Returning a file extension if the system is macOS.
- Telling the updater the current version is the latest if the platform isn't found.