### PR TITLE
Feature/youtube playlist download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+output/*
 build/*
 dist/*
 __pycache__/*

--- a/gui.py
+++ b/gui.py
@@ -37,6 +37,15 @@ def _video_dl() -> None:
         ],
         [Sg.Text(get_text(GuiField.link), key="TextLink")],
         [Sg.Input(key="url")],
+        [
+            Sg.Checkbox(
+                get_text(GuiField.is_playlist),
+                default=False,
+                checkbox_color="black",
+                enable_events=True,
+                key="IsPlaylist",
+            )
+        ],
         [Sg.Text(get_text(GuiField.destination), key="TextDestination")],
         [Sg.Input(download_path, key="path"), Sg.FolderBrowse(button_text="...")],
         [

--- a/lang.py
+++ b/lang.py
@@ -13,6 +13,7 @@ class GuiField(enum.Enum):
     # Main window static text
     incorrect_timestamp = enum.auto()
     link = enum.auto()
+    is_playlist = enum.auto()
     download = enum.auto()
     destination = enum.auto()
     start = enum.auto()
@@ -74,6 +75,11 @@ def get_text(field: GuiField) -> str:
             Language.english: "Link",
             Language.french: "Lien",
             Language.german: "Link",
+        },
+        GuiField.is_playlist: {
+            Language.english: "Playlist",
+            Language.french: "Playlist",
+            Language.german: "Wiedergabeliste",
         },
         GuiField.download: {
             Language.english: "Download",

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -171,10 +171,12 @@ def download_progress_bar(d):
             "-" if downloaded == "-" or total == 0 else int(downloaded / total * 100)
         )
 
-        playlist_index = 1 if not d['info_dict']['playlist_index'] else d['info_dict']['playlist_index']
-        n_entries = 1 if not d['info_dict']['playlist_index'] else d['info_dict']['n_entries']
+        if not d['info_dict']['playlist_index'] or d['info_dict']['n_entries'] == 1:
+            percent_str = f"{progress_percent}%"
+        else:
+            percent_str = f"{progress_percent}% ({d['info_dict']['playlist_index']}/{d['info_dict']['n_entries']})"
 
-        DL_PROGRESS_WINDOW["PROGINFOS1"].update(f"{progress_percent}% ({playlist_index - 1}/{n_entries})")
+        DL_PROGRESS_WINDOW["PROGINFOS1"].update(percent_str)
         DL_PROGRESS_WINDOW["-PROG-"].update(progress_percent)
         now = datetime.datetime.now()
         delta_ms = (now - TIME_LAST_UPDATE).seconds * 1000 + (

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -1,4 +1,6 @@
 import datetime
+import shutil
+
 import PySimpleGUI as Sg
 import yt_dlp
 import os
@@ -39,10 +41,27 @@ def video_dl(values: Dict) -> None:
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         infos_ydl = ydl.extract_info(values["url"])
     DL_PROGRESS_WINDOW.close()
+
+    if "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
+        for infos_ydl_entry in infos_ydl["entries"]:
+            _post_download(values, ydl, infos_ydl_entry)
+    else:
+        _post_download(values, ydl, infos_ydl)
+
+
+def _post_download(values: Dict, ydl, infos_ydl):
+    """
+    Execute all needed processes after a youtube video download :
+    - Execute not AudioOnly process
+    - Move output file(s)
+    """
     ext = "mp3" if values["AudioOnly"] else infos_ydl["ext"]
     full_path = os.path.splitext(ydl.prepare_filename(infos_ydl))[0] + "." + ext
     if not values["AudioOnly"]:
         post_process_dl(full_path, values["TargetCodec"])
+
+    # Move the output file to the user specified output directory
+    shutil.move(full_path, os.path.join(values['path'], full_path))
 
 
 def _gen_query(
@@ -75,9 +94,9 @@ def _gen_query(
         "trim_file_name": 250,
         "outtmpl": os.path.join("%(title).100s - %(uploader)s.%(ext)s"),
         "progress_hooks": [download_progress_bar],
+        "compat_opts": ["no-direct-merge"],
         # 'verbose': True,
     }
-    options["compat_opts"] = ["no-direct-merge"]
     video_format = ""
     acodecs = ["aac", "mp3"] if audio_only else ["aac", "mp3", "mp4a"]
     for acodec in acodecs:

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -54,8 +54,8 @@ def _post_download(values: Dict, ydl, infos_ydl):
     """
     Execute all needed processes after a youtube video download :
     - Execute not AudioOnly process
-    - Move output file(s)
     """
+
     ext = "mp3" if values["AudioOnly"] else infos_ydl["ext"]
     full_path = os.path.splitext(ydl.prepare_filename(infos_ydl))[0] + "." + ext
     if not values["AudioOnly"]:

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -42,9 +42,11 @@ def video_dl(values: Dict) -> None:
         infos_ydl = ydl.extract_info(values["url"])
     DL_PROGRESS_WINDOW.close()
 
-    if "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
+    if values['IsPlaylist'] and "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
         for infos_ydl_entry in infos_ydl["entries"]:
             _post_download(values, ydl, infos_ydl_entry)
+    elif "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
+        _post_download(values, ydl, infos_ydl["entries"][0])
     else:
         _post_download(values, ydl, infos_ydl)
 

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -1,5 +1,4 @@
 import datetime
-import shutil
 
 import PySimpleGUI as Sg
 import yt_dlp
@@ -62,9 +61,6 @@ def _post_download(values: Dict, ydl, infos_ydl):
     if not values["AudioOnly"]:
         post_process_dl(full_path, values["TargetCodec"])
 
-    # Move the output file to the user specified output directory
-    shutil.move(full_path, os.path.join(values['path'], full_path))
-
 
 def _gen_query(
     h: int,
@@ -94,7 +90,7 @@ def _gen_query(
         "noplaylist": True,
         "overwrites": True,
         "trim_file_name": 250,
-        "outtmpl": os.path.join("%(title).100s - %(uploader)s.%(ext)s"),
+        "outtmpl": os.path.join(f"{path}", "%(title).100s - %(uploader)s.%(ext)s"),
         "progress_hooks": [download_progress_bar],
         "compat_opts": ["no-direct-merge"],
         # 'verbose': True,
@@ -145,6 +141,8 @@ def _gen_query(
 
 
 def download_progress_bar(d):
+    print(f"D = {d}")
+
     global CANCELED, DL_PROGRESS_WINDOW, TIME_LAST_UPDATE
     speed = (
         "-"

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -40,6 +40,7 @@ def video_dl(values: Dict) -> None:
     )
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         infos_ydl = ydl.extract_info(values["url"])
+
     DL_PROGRESS_WINDOW.close()
 
     if "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
@@ -142,8 +143,6 @@ def _gen_query(
 
 
 def download_progress_bar(d):
-    print(f"D = {d}")
-
     global CANCELED, DL_PROGRESS_WINDOW, TIME_LAST_UPDATE
     speed = (
         "-"
@@ -171,7 +170,11 @@ def download_progress_bar(d):
         progress_percent = (
             "-" if downloaded == "-" or total == 0 else int(downloaded / total * 100)
         )
-        DL_PROGRESS_WINDOW["PROGINFOS1"].update(f"{progress_percent}%")
+
+        playlist_index = 1 if not d['info_dict']['playlist_index'] else d['info_dict']['playlist_index']
+        n_entries = 1 if not d['info_dict']['playlist_index'] else d['info_dict']['n_entries']
+
+        DL_PROGRESS_WINDOW["PROGINFOS1"].update(f"{progress_percent}% ({playlist_index - 1}/{n_entries})")
         DL_PROGRESS_WINDOW["-PROG-"].update(progress_percent)
         now = datetime.datetime.now()
         delta_ms = (now - TIME_LAST_UPDATE).seconds * 1000 + (

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -34,7 +34,7 @@ def video_dl(values: Dict) -> None:
         values["AudioOnly"],
         values["path"],
         values["Subtitles"],
-        not values["IsPlaylist"],
+        values["IsPlaylist"],
         trim_start,
         trim_end,
     )
@@ -68,7 +68,7 @@ def _gen_query(
     audio_only: bool,
     path: str,
     subtitles: bool,
-    first_of_playlist: bool,
+    playlist: bool,
     start: str,
     end: str,
 ) -> Dict[str, Any]:
@@ -88,12 +88,12 @@ def _gen_query(
         keep_on_top=True,
     )
     options = {
-        "noplaylist": True,
+        "noplaylist": not playlist,
         "overwrites": True,
         "trim_file_name": 250,
         "outtmpl": os.path.join(f"{path}", "%(title).100s - %(uploader)s.%(ext)s"),
+        "playlist_items": None if playlist else "1",
         "progress_hooks": [download_progress_bar],
-        "playlist_items": "1" if first_of_playlist else None,
         "compat_opts": ["no-direct-merge"],
         # 'verbose': True,
     }

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -34,6 +34,7 @@ def video_dl(values: Dict) -> None:
         values["AudioOnly"],
         values["path"],
         values["Subtitles"],
+        not values["IsPlaylist"],
         trim_start,
         trim_end,
     )
@@ -41,11 +42,9 @@ def video_dl(values: Dict) -> None:
         infos_ydl = ydl.extract_info(values["url"])
     DL_PROGRESS_WINDOW.close()
 
-    if values['IsPlaylist'] and "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
+    if "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
         for infos_ydl_entry in infos_ydl["entries"]:
             _post_download(values, ydl, infos_ydl_entry)
-    elif "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
-        _post_download(values, ydl, infos_ydl["entries"][0])
     else:
         _post_download(values, ydl, infos_ydl)
 
@@ -68,6 +67,7 @@ def _gen_query(
     audio_only: bool,
     path: str,
     subtitles: bool,
+    first_of_playlist: bool,
     start: str,
     end: str,
 ) -> Dict[str, Any]:
@@ -92,6 +92,7 @@ def _gen_query(
         "trim_file_name": 250,
         "outtmpl": os.path.join(f"{path}", "%(title).100s - %(uploader)s.%(ext)s"),
         "progress_hooks": [download_progress_bar],
+        "playlist_items": "1" if first_of_playlist else None,
         "compat_opts": ["no-direct-merge"],
         # 'verbose': True,
     }

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -44,7 +44,7 @@ def video_dl(values: Dict) -> None:
     DL_PROGRESS_WINDOW.close()
 
     if "_type" in infos_ydl.keys() and infos_ydl["_type"] == "playlist":
-        for infos_ydl_entry in infos_ydl["entries"]:
+        for video_index, infos_ydl_entry in enumerate(infos_ydl["entries"]):
             _post_download(values, ydl, infos_ydl_entry)
     else:
         _post_download(values, ydl, infos_ydl)


### PR DESCRIPTION
The PR brings fixes :

Fixes :

Fix an error with "post_process_dl for not AudioOnly" for playlist download
Move the downloaded files into the user specified output directory

(Because I deleted by accident the branch on my fork, I recreate [this](https://github.com/Kenshin9977/video-dl/pull/9) pull request...)

Edited according to maintainer remarks :

- [x] Prefer the `f"{var}"` syntax rather than `"{}".format(var) `
- [x] Use `os.join` instead of just `'/'` as it is os dependant.
- [x] Use `shutil.move` instead of `Path.rename` (which uses `os.rename`) as otherwise it won't work if the new location is on another drive.
- [x] You should put a `_` at the beginning of this function's name
- [x] Add a GUI tick for playlist download (discusses needed [here](https://github.com/Kenshin9977/video-dl/pull/9#discussion_r777162216))