### PR TITLE
Rudimentary Support for Audio Only Codec Selection 

### DIFF
--- a/ffmpeg_handler.py
+++ b/ffmpeg_handler.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import re
 import ffmpeg
 import PySimpleGUI as Sg
+
 
 from typing import List
 from subprocess import Popen, PIPE, STDOUT, run

--- a/gui.py
+++ b/gui.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import logging
 import traceback
 import platform
 import PySimpleGUI as Sg
 
-from typing import Dict
-from hwaccel_handler import _get_encoders_list
-from updater import Updater
+import ytdlp_handler
+
 from gen_new_version import APP_VERSION
+from hwaccel_handler import _get_encoders_list
 from lang import (
     GuiField,
     get_available_languages_name,
@@ -14,7 +16,8 @@ from lang import (
     get_text,
     set_current_language,
 )
-from ytdlp_handler import *
+from typing import Dict
+from updater import Updater
 from yt_dlp import utils
 
 gpus_possible_encoders = _get_encoders_list()
@@ -60,7 +63,7 @@ def _video_dl() -> None:
                 window["error"].update(visible=False)
                 # noinspection PyBroadException
                 try:
-                    video_dl(values)
+                    ytdlp_handler.video_dl(values)
                 except ValueError:
                     logging.error(traceback.format_exc())
                     window["error"].update(f"{get_text(GuiField.dl_cancel)}", visible=True, text_color="yellow")
@@ -73,7 +76,7 @@ def _video_dl() -> None:
                         visible=True,
                         text_color="red",
                     )
-                    DL_PROGRESS_WINDOW.close()
+                    ytdlp_handler.DL_PROGRESS_WINDOW.close()
                 except Exception as e:
                     logging.error(traceback.format_exc())
                     window["error"].update(

--- a/lang.py
+++ b/lang.py
@@ -129,7 +129,7 @@ def get_text(field: GuiField) -> str:
             Language.german: "Codec für video",
         },
         GuiField.acodec: {
-            Language.english: "Audio codec",
+            Language.english: "Audio only codec",
             Language.french: "Codec audio",
             Language.german: "Codec für audio",
         },

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -1,13 +1,14 @@
-import datetime
+from __future__ import annotations
 
+import datetime
 import PySimpleGUI as Sg
 import quantiphy
-import yt_dlp
 import os
 
 from typing import Any, Dict
 from quantiphy import Quantity
 from ffmpeg_handler import post_process_dl
+from yt_dlp import YoutubeDL
 from yt_dlp.postprocessor.ffmpeg import EXT_TO_OUT_FORMATS
 from yt_dlp.utils import traverse_obj
 
@@ -44,7 +45,7 @@ def video_dl(values: Dict) -> None:
         values["PlaylistItemsCheckbox"]
     )
 
-    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+    with YoutubeDL(ydl_opts) as ydl:
         infos_ydl = ydl.extract_info(values["url"])
         DL_PROGRESS_WINDOW.close()
 

--- a/ytdlp_handler.py
+++ b/ytdlp_handler.py
@@ -142,7 +142,11 @@ def _gen_query(
         options["external_downloader"] = "ffmpeg"
         options["concurrent_fragments"] = 20
         # options['external_downloader_args']['ffmpeg_i'].extend(['-stats_period', '0.05'])
-        if end:
+        if not start and end:
+            options["external_downloader_args"] = {
+                "ffmpeg_i": ["-ss", "00:00:00", "-to", end]
+            }
+        elif start and end:
             options["external_downloader_args"] = {
                 "ffmpeg_i": ["-ss", start, "-to", end]
             }


### PR DESCRIPTION
## What?
Rudimentary Support for Audio Only Codec Selection
## Why?
I prefer the flexibility of selecting my own audio codec, rather than relying on MP3.
## How?
I created an additional combo box in gui.py for audio-only codec selection (referred to by the key "TargetACodec"), and passed the "TargetACodec" value to the audio_only post processor in _gen_query function in ytdlp_handler.py
## Testing?
I tested the codec selection functionality with both singular youtube videos, as well as several youtube playlists with success.
## Screenshots (optional)
![gui_addition](https://user-images.githubusercontent.com/83386462/174688410-94ba4d04-1e69-44a8-8f5b-aa15acedaa3f.png)
Screenshot of the GUI Addition 
## Anything Else

The audio-only codec selection box is currently enabled by default when ideally it should only be enabled when the audio-only checkbox is selected. However, I think this is a good starter implementation for a valuable feature for the end-user.