### PR TITLE
Harden the build pipeline and fix the Windows ffmpeg install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,16 @@ concurrency:
 permissions:
   contents: write
 
+# Every third party binary is pinned to an immutable tag. The rolling `latest`
+# tag these projects also publish is mutable: its assets are replaced in place,
+# so a release could never be rebuilt byte for byte, and a half finished upstream
+# build could silently swap what we ship. Bump these deliberately.
+env:
+  FFMPEG_ANDROID_TAG: autobuild-2026-06-15-18-44
+  ARIA2_TAG: release-2.0.1
+  QUICKJS_COMMIT: 04be246001599f5995fa2f2d8c91a0f198d3f34c
+  EJS_VERSION: "0.5.0"
+
 jobs:
   build:
     strategy:
@@ -38,12 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
+          enable-cache: true
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv sync --locked --extra dev
 
       - name: Generate macOS icon
         if: runner.os == 'macOS'
@@ -60,20 +70,24 @@ jobs:
           iconutil -c icns "$ICONSET" -o icon.icns
 
       - name: Build binary
-        run: pyinstaller ${{ matrix.spec }}
+        run: uv run pyinstaller ${{ matrix.spec }}
 
+      # `--help` exits inside argparse, before the app imports flet, yt_dlp or
+      # tufup, so it cannot catch a missing PyInstaller hiddenimport. `--selftest`
+      # imports them all and exits, without initializing paths (that would try to
+      # download ffmpeg on the runner).
       - name: Smoke test (Windows)
         if: runner.os == 'Windows'
         shell: bash
-        run: ./dist/video-dl.exe --help
+        run: ./dist/video-dl.exe --selftest
 
       - name: Smoke test (Linux)
         if: runner.os == 'Linux'
-        run: ./dist/video-dl --help
+        run: ./dist/video-dl --selftest
 
       - name: Smoke test (macOS)
         if: runner.os == 'macOS'
-        run: ./dist/video-dl.app/Contents/MacOS/video-dl --help
+        run: ./dist/video-dl.app/Contents/MacOS/video-dl --selftest
 
       - name: Package artifact (Windows)
         if: runner.os == 'Windows'
@@ -120,37 +134,48 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ANDROID_LIBS: android_libs/arm64-v8a
+      NDK_VERSION: 27.2.12479018
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
+          enable-cache: true
 
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "21"
+          cache: gradle
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          cache: true
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Install NDK
-        run: sdkmanager "ndk;27.2.12479018"
+      - name: Cache the NDK
+        id: ndk-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
+          key: ndk-${{ env.NDK_VERSION }}
+
+      - name: Install the NDK
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
+        run: sdkmanager "ndk;${NDK_VERSION}"
 
       - name: Install Python dependencies
-        run: pip install -e "." flet
+        run: uv sync --locked
 
       - name: Fetch FFmpeg
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "$ANDROID_LIBS"
-          gh release download latest --repo Kenshin9977/FFmpeg-Builds \
+          gh release download "$FFMPEG_ANDROID_TAG" --repo Kenshin9977/FFmpeg-Builds \
             --pattern "ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz" --dir /tmp --clobber
           tar xf /tmp/ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz -C /tmp
           cp /tmp/ffmpeg-master-latest-androidarm64-gpl-shared/bin/ffmpeg \
@@ -162,16 +187,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo Kenshin9977/aria2 \
-            --pattern "aria2c-android-aarch64" --dir /tmp --clobber
+          gh release download "$ARIA2_TAG" --repo Kenshin9977/aria2 \
+            --pattern "aria2c-android-aarch64" --pattern "SHA256SUMS" --dir /tmp --clobber
+          (cd /tmp && grep " aria2c-android-aarch64$" SHA256SUMS | sha256sum -c -)
           cp /tmp/aria2c-android-aarch64 "$ANDROID_LIBS/aria2c"
           chmod +x "$ANDROID_LIBS/aria2c"
 
+      - name: Cache the QuickJS build
+        id: quickjs-cache
+        uses: actions/cache@v4
+        with:
+          path: android_libs/qjs
+          key: quickjs-${{ env.QUICKJS_COMMIT }}-ndk-${{ env.NDK_VERSION }}
+
       - name: Build QuickJS for ARM64
+        if: steps.quickjs-cache.outputs.cache-hit != 'true'
         run: |
           NDK_BIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          git clone --depth 1 https://github.com/bellard/quickjs.git /tmp/quickjs-bellard
+          git clone https://github.com/bellard/quickjs.git /tmp/quickjs-bellard
           cd /tmp/quickjs-bellard
+          git checkout "$QUICKJS_COMMIT"
           CC="$NDK_BIN/clang --target=aarch64-linux-android24 --sysroot=$NDK_BIN/../sysroot"
           CFLAGS="-D_GNU_SOURCE -DCONFIG_VERSION=\"$(cat VERSION)\" -O2 -flto -funsigned-char -fwrapv"
           for f in qjs quickjs quickjs-libc cutils dtoa libregexp libunicode; do
@@ -181,13 +216,17 @@ jobs:
           $CC $CFLAGS -c -o repl_stub.o repl_stub.c
           $CC -static -flto -o qjs qjs.o quickjs.o quickjs-libc.o cutils.o dtoa.o libregexp.o libunicode.o repl_stub.o -lm -ldl
           $NDK_BIN/llvm-strip qjs
-          cp qjs "$GITHUB_WORKSPACE/$ANDROID_LIBS/qjs"
+          mkdir -p "$GITHUB_WORKSPACE/android_libs"
+          cp qjs "$GITHUB_WORKSPACE/android_libs/qjs"
+
+      - name: Stage QuickJS
+        run: cp android_libs/qjs "$ANDROID_LIBS/qjs"
 
       - name: Fetch EJS solver lib
         run: |
-          EJS_DIR=$(python -c "import yt_dlp, os; print(os.path.join(os.path.dirname(yt_dlp.__file__), 'extractor/youtube/jsc/_builtin/vendor'))")
+          EJS_DIR=$(uv run python -c "import yt_dlp, os; print(os.path.join(os.path.dirname(yt_dlp.__file__), 'extractor/youtube/jsc/_builtin/vendor'))")
           curl -fSL -o "$EJS_DIR/yt.solver.lib.js" \
-            https://github.com/yt-dlp/ejs/releases/download/0.5.0/yt.solver.lib.js
+            "https://github.com/yt-dlp/ejs/releases/download/${EJS_VERSION}/yt.solver.lib.js"
 
       - name: Inject native libs
         run: |
@@ -199,9 +238,14 @@ jobs:
           cp "$ANDROID_LIBS/qjs" "$JNILIBS/libqjs.so"
           cp "$ANDROID_LIBS/aria2c" "$JNILIBS/libaria2c.so"
 
+      # arm64-v8a only, on purpose. The native libs above are injected into that
+      # ABI alone, and ffmpeg, aria2c and qjs are only built for aarch64 upstream,
+      # so an armeabi-v7a or x86_64 APK would install and then fail at the first
+      # download or mux. Publishing one working APK beats publishing three of
+      # which two are broken.
       - name: Build APK
         run: |
-          flet build apk \
+          uv run flet build apk \
             --project video-dl \
             --org com.videodl \
             --product "Video-dl" \
@@ -217,10 +261,22 @@ jobs:
             --android-permissions INTERNET=True WRITE_EXTERNAL_STORAGE=True READ_EXTERNAL_STORAGE=True MANAGE_EXTERNAL_STORAGE=True \
             --android-adaptive-icon-background "#7C3AED"
 
+      - name: Keep only the ABI we ship
+        run: |
+          shopt -s nullglob
+          apk=(build/apk/*arm64-v8a*.apk)
+          if [ ${#apk[@]} -ne 1 ]; then
+            echo "::error::expected exactly one arm64-v8a APK, found ${#apk[@]}"
+            exit 1
+          fi
+          mkdir -p release_apk
+          mv "${apk[0]}" release_apk/video-dl-arm64-v8a.apk
+          ls -lh release_apk/
+
       - uses: actions/upload-artifact@v4
         with:
-          name: android-apks
-          path: build/apk/*.apk
+          name: android-apk
+          path: release_apk/video-dl-arm64-v8a.apk
 
   sign:
     needs: build
@@ -228,12 +284,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
+          enable-cache: true
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv sync --locked --extra dev
 
       - uses: actions/download-artifact@v4
         with:
@@ -248,23 +304,38 @@ jobs:
           echo "${{ secrets.TUFUP_PUBLIC_KEY }}" | base64 -d > keystore/video_dl_key.pub
           echo "${{ secrets.TUFUP_CONFIG }}" | base64 -d > .tufup-repo-config
 
+      # The tufup repository is the state of the update channel: its snapshot and
+      # timestamp version numbers only ever go up, and a client rejects metadata
+      # that goes backwards. Restoring a fresh repo instead of the real one would
+      # reset those counters to 1 and permanently brick auto-update for everyone
+      # already installed. So a failed restore fails the release. Bootstrapping an
+      # empty channel is a deliberate act: set the TUFUP_BOOTSTRAP repository
+      # variable to 1 for that one run.
       - name: Restore tufup repository
         env:
           GH_TOKEN: ${{ github.token }}
           TUFUP_REPO_ARCHIVE: ${{ secrets.TUFUP_REPO_ARCHIVE }}
+          TUFUP_BOOTSTRAP: ${{ vars.TUFUP_BOOTSTRAP }}
         run: |
-          if gh release download --repo ${{ github.repository }} \
-              --pattern "tufup-repo.tar.gz" --dir /tmp 2>/dev/null; then
+          set -euo pipefail
+          if gh release download --repo "$GITHUB_REPOSITORY" --pattern "tufup-repo.tar.gz" --dir /tmp; then
             tar -xzf /tmp/tufup-repo.tar.gz
-            echo "Restored tufup repo from previous release"
-          elif [ -n "$TUFUP_REPO_ARCHIVE" ]; then
+            echo "Restored the tufup repo from the previous release"
+          elif [ -n "${TUFUP_REPO_ARCHIVE:-}" ]; then
             echo "$TUFUP_REPO_ARCHIVE" | base64 -d | tar -xzf -
-            echo "Restored tufup repo from secret"
-          else
+            echo "Restored the tufup repo from the TUFUP_REPO_ARCHIVE secret"
+          elif [ "${TUFUP_BOOTSTRAP:-}" = "1" ]; then
             mkdir -p repository/metadata repository/targets
             cp root.json repository/metadata/root.json
-            echo "Bootstrapped fresh tufup repo"
+            echo "Bootstrapped a fresh tufup repo (TUFUP_BOOTSTRAP=1)"
+          else
+            echo "::error::Could not restore the tufup repository from the previous release."
+            echo "::error::Publishing now would reset TUF metadata versions and break auto-update"
+            echo "::error::for every installed client. Fix the restore, or set the TUFUP_BOOTSTRAP"
+            echo "::error::repository variable to 1 if you really mean to start a fresh channel."
+            exit 1
           fi
+          test -f repository/metadata/root.json
 
       - name: Extract version from tag
         id: version
@@ -272,7 +343,7 @@ jobs:
 
       - name: Sign all platform artifacts
         run: |
-          python -m tools.ci_sign \
+          uv run python -m tools.ci_sign \
             --version "${{ steps.version.outputs.version }}" \
             --artifacts-dir artifacts \
             --keys-dir keystore \
@@ -305,14 +376,16 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # No `|| true` here. A missing binary used to produce a green release with
+      # the binary silently absent from it.
       - name: Organize release assets
         run: |
+          set -euo pipefail
           mkdir -p binaries tufup
-          mv artifacts/video-dl-windows.exe binaries/ 2>/dev/null || true
-          mv artifacts/video-dl-linux binaries/ 2>/dev/null || true
-          mv artifacts/video-dl-macos.dmg binaries/ 2>/dev/null || true
-          mv artifacts/*.apk binaries/ 2>/dev/null || true
-          mv artifacts/* tufup/ 2>/dev/null || true
+          for binary in video-dl-windows.exe video-dl-linux video-dl-macos.dmg video-dl-arm64-v8a.apk; do
+            mv "artifacts/$binary" binaries/
+          done
+          mv artifacts/* tufup/
           echo "=== Binaries ===" && ls -la binaries/
           echo "=== Tufup ===" && ls -la tufup/
 
@@ -324,13 +397,9 @@ jobs:
           body: |
             ## Download
 
-            | Windows | macOS | Linux |
-            |:-------:|:-----:|:-----:|
-            | [video-dl-windows.exe](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-windows.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-linux) |
-
-            | Android (ARM64) | Android (ARM 32-bit) | Android (x86_64) |
-            |:---------------:|:--------------------:|:-----------------:|
-            | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-arm64-v8a.apk) | [video-dl-armeabi-v7a.apk](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-armeabi-v7a.apk) | [video-dl-x86_64.apk](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-x86_64.apk) |
+            | Windows | macOS | Linux | Android (ARM64) |
+            |:-------:|:-----:|:-----:|:---------------:|
+            | [video-dl-windows.exe](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-windows.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-linux) | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-arm64-v8a.apk) |
 
             <details>
             <summary>Auto-update files (internal)</summary>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
-      - run: pip install ruff mypy
-      - run: ruff check .
-      - run: ruff format --check .
-      - run: mypy .
+          enable-cache: true
+      - run: uv sync --locked --extra dev
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      - run: uv run mypy .
 
+  # The shipped binary is Windows first, and the Windows specific paths (winreg,
+  # the ffmpeg install under LOCALAPPDATA) used to never run in CI on any OS.
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
-      - run: pip install -e ".[dev]"
-      - run: pytest --cov=core --cov=gui --cov=i18n --cov=utils --cov-report=term-missing
+          enable-cache: true
+      - run: uv sync --locked --extra dev
+      - run: uv run pytest --cov=core --cov=gui --cov=i18n --cov=utils --cov-report=term-missing
+
+  # A release tag used to be the first time PyInstaller ever ran against a change,
+  # and release.sh pushes the tag before the build proves anything. Freeze the
+  # binary here instead, and run the same import selftest the release runs, so a
+  # broken spec or a missing hiddenimport fails on the pull request.
+  package:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv sync --locked --extra dev
+      - run: uv run pyinstaller specs/Windows-video-dl.spec
+      - name: Smoke test the frozen binary
+        shell: bash
+        run: ./dist/video-dl.exe --selftest

--- a/main.py
+++ b/main.py
@@ -7,13 +7,51 @@ from videodl_logger import videodl_logger
 warnings.filterwarnings("ignore", message="urllib3.*doesn't match a supported version")
 
 
+# yt-dlp imports these lazily, inside try/except ImportError, and degrades
+# silently when they are absent: no audio tagging without mutagen, no AES without
+# Cryptodome, no websocket transport without websockets. A frozen binary that
+# dropped one of them looks perfectly healthy until a user hits the code path.
+_REQUIRED_YT_DLP_DEPS = frozenset({"Cryptodome", "brotli", "certifi", "mutagen", "websockets", "yt_dlp_ejs"})
+
+
+def selftest() -> None:
+    """Import every heavy dependency, check yt-dlp is whole, and exit.
+
+    The packaged binary is the only place a missing PyInstaller hiddenimport
+    shows up, and it shows up at startup. CI runs this against the frozen
+    executable so the failure lands on a pull request instead of in a published
+    release. Paths are deliberately not initialized: that would try to download
+    ffmpeg on a bare runner.
+    """
+    import flet  # noqa: F401
+    import tufup  # noqa: F401
+    from yt_dlp.dependencies import available_dependencies
+    from yt_dlp.version import __version__ as yt_dlp_version
+
+    from core.download import download  # noqa: F401
+    from gui.app import videodl_gui  # noqa: F401
+    from sys_vars import init_paths  # noqa: F401
+    from updater.client import check_for_updates  # noqa: F401
+
+    missing = _REQUIRED_YT_DLP_DEPS - set(available_dependencies)
+    if missing:
+        raise SystemExit(f"yt-dlp is missing dependencies: {', '.join(sorted(missing))}")
+
+    print(f"selftest ok (yt-dlp {yt_dlp_version})")
+
+
 def main():
     parser = argparse.ArgumentParser(description="video-dl")
     parser.add_argument("--debug", action="store_true", help="Enable debug logs for video-dl only")
     parser.add_argument(
         "--verbose", action="store_true", help="Enable debug logs for all libraries (Flet, urllib3, etc.)"
     )
+    parser.add_argument("--selftest", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
+
+    if args.selftest:
+        selftest()
+        return
 
     videodl_logger(debug=args.debug or args.verbose, verbose=args.verbose)
     logger = logging.getLogger("videodl")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,15 @@ dependencies = [
     "flet>=0.81",
     "quantiphy",
     "tomlkit",
-    "yt-dlp-ejs",
-    "yt-dlp-enhanced-progress>=2026.3.3",
+    # Our yt-dlp fork, republished under this name. Pinned exactly: yt-dlp is
+    # frozen into the binary at build time anyway, so a floating spec buys no
+    # fixes for users, it only makes two builds of the same tag differ. Bump it
+    # deliberately when the fork republishes.
+    #
+    # [default] pulls yt-dlp's own recommended runtime deps (mutagen for audio
+    # tagging, websockets, pycryptodomex, brotli, certifi, yt-dlp-ejs). Without
+    # it the shipped yt-dlp silently loses those code paths.
+    "yt-dlp-enhanced-progress[default]==2026.3.13.160948",
 ]
 
 [project.optional-dependencies]

--- a/specs/Linux-video-dl.spec
+++ b/specs/Linux-video-dl.spec
@@ -13,7 +13,16 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[(os.path.join(ROOTDIR, 'root.json'), '.')] + flet_data + flet_desktop_data,
-    hiddenimports=['flet_desktop'],
+    # yt-dlp imports these inside try/except ImportError and quietly does without
+    # them, so a binary that failed to collect one still starts and only breaks
+    # later, on audio tagging or AES. main.py --selftest enforces their presence.
+    hiddenimports=[
+        'flet_desktop',
+        'Cryptodome.Cipher.AES',
+        'brotli',
+        'mutagen',
+        'websockets',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/specs/Windows-video-dl.spec
+++ b/specs/Windows-video-dl.spec
@@ -16,7 +16,16 @@ a = Analysis(
         (os.path.join(ROOTDIR, 'icon.ico'), '.'),
         (os.path.join(ROOTDIR, 'assets'), 'assets'),
     ] + flet_data + flet_desktop_data,
-    hiddenimports=['flet_desktop'],
+    # yt-dlp imports these inside try/except ImportError and quietly does without
+    # them, so a binary that failed to collect one still starts and only breaks
+    # later, on audio tagging or AES. main.py --selftest enforces their presence.
+    hiddenimports=[
+        'flet_desktop',
+        'Cryptodome.Cipher.AES',
+        'brotli',
+        'mutagen',
+        'websockets',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/specs/macOS-video-dl.spec
+++ b/specs/macOS-video-dl.spec
@@ -17,7 +17,16 @@ a = Analysis(
         (os.path.join(ROOTDIR, 'icon.icns'), '.'),
         (os.path.join(ROOTDIR, 'assets'), 'assets'),
     ] + flet_data + flet_desktop_data,
-    hiddenimports=['flet_desktop'],
+    # yt-dlp imports these inside try/except ImportError and quietly does without
+    # them, so a binary that failed to collect one still starts and only breaks
+    # later, on audio tagging or AES. main.py --selftest enforces their presence.
+    hiddenimports=[
+        'flet_desktop',
+        'Cryptodome.Cipher.AES',
+        'brotli',
+        'mutagen',
+        'websockets',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/tests/test_aria2_install.py
+++ b/tests/test_aria2_install.py
@@ -1,0 +1,76 @@
+import hashlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault("flet", MagicMock())
+
+# Other test modules replace utils.aria2_install with a MagicMock in sys.modules.
+# Drop that first, so the names below are bound to the real module whatever the
+# collection order turns out to be.
+sys.modules.pop("utils.aria2_install", None)
+
+from utils.aria2_install import _ARIA2C_RELEASE_TAG, verify_download  # noqa: E402
+
+ASSET = "aria2c-linux-x86_64"
+
+
+def _sums_response(payload: bytes, asset: str = ASSET):
+    """Fake the SHA256SUMS asset published alongside the binaries."""
+    digest = hashlib.sha256(payload).hexdigest()
+    body = f"{digest}  {asset}\nffffffff  aria2c-macos-arm64\n".encode()
+    response = MagicMock()
+    response.read.return_value = body
+    response.__enter__ = lambda self: self
+    response.__exit__ = lambda *_: None
+    return response
+
+
+class TestVerifyDownload:
+    def test_accepts_a_matching_digest(self, tmp_path):
+        payload = b"aria2c binary"
+        binary = tmp_path / ASSET
+        binary.write_bytes(payload)
+
+        with patch("urllib.request.urlopen", return_value=_sums_response(payload)):
+            verify_download(str(binary), ASSET)
+
+    def test_rejects_a_tampered_binary(self, tmp_path):
+        binary = tmp_path / ASSET
+        binary.write_bytes(b"not what was published")
+
+        with (
+            patch("urllib.request.urlopen", return_value=_sums_response(b"aria2c binary")),
+            pytest.raises(ValueError, match="Checksum mismatch"),
+        ):
+            verify_download(str(binary), ASSET)
+
+    def test_rejects_an_asset_absent_from_the_sums_file(self, tmp_path):
+        payload = b"aria2c binary"
+        binary = tmp_path / ASSET
+        binary.write_bytes(payload)
+
+        with (
+            patch("urllib.request.urlopen", return_value=_sums_response(payload, asset="aria2c-windows-x86_64.exe")),
+            pytest.raises(ValueError, match="No published checksum"),
+        ):
+            verify_download(str(binary), ASSET)
+
+    def test_propagates_a_failure_to_fetch_the_sums_file(self, tmp_path):
+        binary = tmp_path / ASSET
+        binary.write_bytes(b"aria2c binary")
+
+        with (
+            patch("urllib.request.urlopen", side_effect=OSError("network down")),
+            pytest.raises(OSError, match="network down"),
+        ):
+            verify_download(str(binary), ASSET)
+
+
+class TestReleasePinning:
+    def test_desktop_tag_matches_the_tag_bundled_into_the_apk(self):
+        """The APK and the desktop download must ship the same aria2c build."""
+        workflow = Path(__file__).parent.parent / ".github" / "workflows" / "build.yml"
+        assert f"ARIA2_TAG: {_ARIA2C_RELEASE_TAG}" in workflow.read_text(encoding="utf-8")

--- a/tests/test_ffmpeg_install.py
+++ b/tests/test_ffmpeg_install.py
@@ -1,0 +1,84 @@
+import sys
+from unittest.mock import MagicMock
+from zipfile import ZipFile
+
+import pytest
+
+sys.modules.setdefault("flet", MagicMock())
+
+from utils.ffmpeg_install import extract_ffmpeg  # noqa: E402
+
+ARCHIVE_ROOT = "ffmpeg-master-latest-win64-gpl-shared"
+
+
+def _build_archive(tmp_path, names):
+    """Write a zip mimicking the layout of a real FFmpeg-Builds release asset."""
+    zip_path = tmp_path / "ffmpeg.zip"
+    with ZipFile(zip_path, "w") as archive:
+        for name in names:
+            archive.writestr(name, b"binary")
+    return str(zip_path)
+
+
+class TestExtractFfmpeg:
+    def test_flattens_nested_bin_directory(self, tmp_path):
+        zip_path = _build_archive(
+            tmp_path,
+            [
+                f"{ARCHIVE_ROOT}/bin/ffmpeg.exe",
+                f"{ARCHIVE_ROOT}/bin/ffprobe.exe",
+                f"{ARCHIVE_ROOT}/bin/avcodec-62.dll",
+                f"{ARCHIVE_ROOT}/doc/ffmpeg.html",
+                f"{ARCHIVE_ROOT}/lib/avcodec.lib",
+            ],
+        )
+        target = tmp_path / "install"
+        target.mkdir()
+
+        extract_ffmpeg(zip_path, str(target))
+
+        assert (target / "ffmpeg.exe").is_file()
+        assert (target / "ffprobe.exe").is_file()
+        assert (target / "avcodec-62.dll").is_file()
+
+    def test_ignores_everything_outside_bin(self, tmp_path):
+        zip_path = _build_archive(
+            tmp_path,
+            [
+                f"{ARCHIVE_ROOT}/bin/ffmpeg.exe",
+                f"{ARCHIVE_ROOT}/bin/ffprobe.exe",
+                f"{ARCHIVE_ROOT}/doc/ffmpeg.html",
+                f"{ARCHIVE_ROOT}/LICENSE.txt",
+            ],
+        )
+        target = tmp_path / "install"
+        target.mkdir()
+
+        extract_ffmpeg(zip_path, str(target))
+
+        assert sorted(p.name for p in target.iterdir()) == ["ffmpeg.exe", "ffprobe.exe"]
+
+    def test_path_traversal_member_lands_inside_target(self, tmp_path):
+        zip_path = _build_archive(
+            tmp_path,
+            [
+                f"{ARCHIVE_ROOT}/bin/ffmpeg.exe",
+                f"{ARCHIVE_ROOT}/bin/ffprobe.exe",
+                "../../bin/evil.dll",
+            ],
+        )
+        target = tmp_path / "install"
+        target.mkdir()
+
+        extract_ffmpeg(zip_path, str(target))
+
+        assert (target / "evil.dll").is_file()
+        assert not (tmp_path.parent / "evil.dll").exists()
+
+    def test_raises_when_the_archive_has_no_ffmpeg(self, tmp_path):
+        zip_path = _build_archive(tmp_path, [f"{ARCHIVE_ROOT}/bin/ffplay.exe"])
+        target = tmp_path / "install"
+        target.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="ffmpeg.exe, ffprobe.exe"):
+            extract_ffmpeg(zip_path, str(target))

--- a/utils/aria2_install.py
+++ b/utils/aria2_install.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import stat
@@ -11,7 +12,9 @@ import flet as ft
 logger = logging.getLogger("videodl")
 
 _ARIA2C_REPO = "Kenshin9977/aria2"
-_ARIA2C_RELEASE_TAG = "release-2.0.0"
+# Keep this tag in sync with ARIA2_TAG in .github/workflows/build.yml, which
+# bundles the Android build of the same release into the APK.
+_ARIA2C_RELEASE_TAG = "release-2.0.1"
 _ARIA2C_BASE_URL = f"https://github.com/{_ARIA2C_REPO}/releases/download/{_ARIA2C_RELEASE_TAG}"
 
 # Map (platform, arch) to release asset name
@@ -27,6 +30,42 @@ _ASSET_MAP = {
 def _get_asset_name() -> str | None:
     key = (system(), machine())
     return _ASSET_MAP.get(key)
+
+
+def _published_sha256(asset: str) -> str | None:
+    """Read an asset's digest from the SHA256SUMS file shipped with the release."""
+    with urllib.request.urlopen(f"{_ARIA2C_BASE_URL}/SHA256SUMS") as response:
+        sums = response.read().decode()
+
+    for line in sums.splitlines():
+        digest, _, name = line.partition(" ")
+        if name.strip() == asset:
+            return digest.strip()
+    return None
+
+
+def _file_sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_download(path: str, asset: str) -> None:
+    """Check a downloaded asset against the digest published with the release.
+
+    Fails closed: we are about to hand this file to the OS as an executable, so
+    an unverifiable download is treated the same as a corrupted one. The caller
+    deletes it and the app runs without aria2c, which only costs download speed.
+    """
+    expected = _published_sha256(asset)
+    if expected is None:
+        raise ValueError(f"No published checksum for {asset}")
+
+    actual = _file_sha256(path)
+    if actual != expected:
+        raise ValueError(f"Checksum mismatch for {asset}: expected {expected}, got {actual}")
 
 
 def get_aria2c_install_folder() -> str:
@@ -78,6 +117,12 @@ def aria2c_progress_page(page: ft.Page) -> None:
             page.update()
 
             urllib.request.urlretrieve(url, install_path, reporthook)
+
+            try:
+                verify_download(install_path, asset)
+            except Exception:
+                os.remove(install_path)
+                raise
 
             # Make executable on non-Windows
             if system() != "Windows":

--- a/utils/ffmpeg_install.py
+++ b/utils/ffmpeg_install.py
@@ -4,9 +4,11 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import threading
 import urllib.request
+from pathlib import PurePosixPath
 from typing import TypedDict
 from zipfile import ZipFile
 
@@ -15,6 +17,35 @@ import flet as ft
 from utils.sys_architecture import ARCHITECTURE
 
 logger = logging.getLogger("videodl")
+
+
+def extract_ffmpeg(zip_path: str, folder_path: str) -> None:
+    """Extract the archive's bin/ directory flat into folder_path.
+
+    FFmpeg-Builds archives nest everything under
+    ffmpeg-master-latest-<arch>-gpl-shared/bin/, while the app looks for
+    ffmpeg.exe and ffprobe.exe directly inside folder_path. The shared build
+    keeps its DLLs in that same bin/ directory, so they come along.
+
+    Members are written under their basename, which makes zip path traversal
+    impossible by construction.
+    """
+    extracted = set()
+    with ZipFile(zip_path, "r") as zip_ref:
+        for member in zip_ref.infolist():
+            if member.is_dir():
+                continue
+            member_path = PurePosixPath(member.filename)
+            if member_path.parent.name != "bin":
+                continue
+            target_path = os.path.join(folder_path, member_path.name)
+            with zip_ref.open(member) as source, open(target_path, "wb") as target:
+                shutil.copyfileobj(source, target)
+            extracted.add(member_path.name)
+
+    missing = {"ffmpeg.exe", "ffprobe.exe"} - extracted
+    if missing:
+        raise FileNotFoundError(f"{', '.join(sorted(missing))} missing from {os.path.basename(zip_path)}")
 
 
 def ffmpeg_progress_page(page: ft.Page) -> None:
@@ -51,14 +82,8 @@ def ffmpeg_progress_page(page: ft.Page) -> None:
             archive_name = download_ffmpeg(bits_archi, folder_path)
             zip_path = os.path.join(folder_path, archive_name)
 
-            with ZipFile(zip_path, "r") as zip_ref:
-                for member in zip_ref.namelist():
-                    member_path = os.path.realpath(os.path.join(folder_path, member))
-                    if not member_path.startswith(
-                        os.path.realpath(folder_path) + os.sep
-                    ) and member_path != os.path.realpath(folder_path):
-                        raise ValueError(f"Zip path traversal blocked: {member}")
-                zip_ref.extractall(folder_path)
+            extract_ffmpeg(zip_path, folder_path)
+            os.remove(zip_path)
 
             progress_bar.value = 1.0
             progress_bar.label = "Download complete"  # type: ignore[attr-defined]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "altgraph"
@@ -22,6 +26,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
 ]
 
 [[package]]
@@ -549,6 +612,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mutagen"
+version = "1.48.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/70/1675da133ea92227da41bf5b24e1c66be597ff736a1533ade41da986852f/mutagen-1.48.1.tar.gz", hash = "sha256:8f95637ab9f6f305cec6bd1294e197debe207998e3e068596563c74f86b0a173", size = 1276978, upload-time = "2026-06-25T09:47:32.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d8/a29e4e3991765e7ce4ed1f7e4074fe1ba9da03e0048639734de60f9cadb9/mutagen-1.48.1-py3-none-any.whl", hash = "sha256:4f077fe87d3fc7fba259aa63d8c026b18382ca6a42ef37c61e16f1b1b5b82fe7", size = 195706, upload-time = "2026-06-25T09:47:30.296Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -711,6 +783,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/00/10edb04777069a42490a38c137099d4b17ba6e36a4e6e28bdc7470e9e853/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7b37e08e3871efe2187bc1fd9320cc81d87caf19816c648f24443483005ff886", size = 2498764, upload-time = "2025-05-17T17:22:21.453Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3f/2872a9c2d3a27eac094f9ceaa5a8a483b774ae69018040ea3240d5b11154/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:91979028227543010d7b2ba2471cf1d1e398b3f183cb105ac584df0c36dac28d", size = 1643012, upload-time = "2025-05-17T17:22:23.702Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/774c2e2b4f6570fbf6a4972161adbb183aeeaa1863bde31e8706f123bf92/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8962204c47464d5c1c4038abeadd4514a133b28748bcd9fa5b6d62e3cec6fa", size = 2187643, upload-time = "2025-05-17T17:22:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a3/71065b24cb889d537954cedc3ae5466af00a2cabcff8e29b73be047e9a19/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33986a0066860f7fcf7c7bd2bc804fa90e434183645595ae7b33d01f3c91ed8", size = 2273762, upload-time = "2025-05-17T17:22:28.313Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0b/ff6f43b7fbef4d302c8b981fe58467b8871902cdc3eb28896b52421422cc/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7947ab8d589e3178da3d7cdeabe14f841b391e17046954f2fbcd941705762b5", size = 2313012, upload-time = "2025-05-17T17:22:30.57Z" },
+    { url = "https://files.pythonhosted.org/packages/02/de/9d4772c0506ab6da10b41159493657105d3f8bb5c53615d19452afc6b315/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c25e30a20e1b426e1f0fa00131c516f16e474204eee1139d1603e132acffc314", size = 2186856, upload-time = "2025-05-17T17:22:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/8b30efcd6341707a234e5eba5493700a17852ca1ac7a75daa7945fcf6427/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:da4fa650cef02db88c2b98acc5434461e027dce0ae8c22dd5a69013eaf510006", size = 2347523, upload-time = "2025-05-17T17:22:35.386Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/02/16868e9f655b7670dbb0ac4f2844145cbc42251f916fc35c414ad2359849/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:58b851b9effd0d072d4ca2e4542bf2a4abcf13c82a29fd2c93ce27ee2a2e9462", size = 2272825, upload-time = "2025-05-17T17:22:37.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/4ca89ac737230b52ac8ffaca42f9c6f1fd07c81a6cd821e91af79db60632/pycryptodomex-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:a9d446e844f08299236780f2efa9898c818fe7e02f17263866b8550c7d5fb328", size = 1772078, upload-time = "2025-05-17T17:22:40Z" },
+    { url = "https://files.pythonhosted.org/packages/73/34/13e01c322db027682e00986873eca803f11c56ade9ba5bbf3225841ea2d4/pycryptodomex-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bc65bdd9fc8de7a35a74cab1c898cab391a4add33a8fe740bda00f5976ca4708", size = 1803656, upload-time = "2025-05-17T17:22:42.139Z" },
+    { url = "https://files.pythonhosted.org/packages/54/68/9504c8796b1805d58f4425002bcca20f12880e6fa4dc2fc9a668705c7a08/pycryptodomex-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c885da45e70139464f082018ac527fdaad26f1657a99ee13eecdce0f0ca24ab4", size = 1707172, upload-time = "2025-05-17T17:22:44.704Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
 ]
 
 [[package]]
@@ -993,14 +1095,13 @@ wheels = [
 
 [[package]]
 name = "video-dl"
-version = "2.2.2"
+version = "2.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "flet" },
     { name = "quantiphy" },
     { name = "tomlkit" },
-    { name = "yt-dlp-ejs" },
-    { name = "yt-dlp-enhanced-progress" },
+    { name = "yt-dlp-enhanced-progress", extra = ["default"] },
 ]
 
 [package.optional-dependencies]
@@ -1038,10 +1139,86 @@ requires-dist = [
     { name = "tomlkit" },
     { name = "tufup", marker = "extra == 'desktop'", specifier = ">=0.10" },
     { name = "tufup", marker = "extra == 'dev'", specifier = ">=0.10" },
-    { name = "yt-dlp-ejs" },
-    { name = "yt-dlp-enhanced-progress", specifier = ">=2026.3.3" },
+    { name = "yt-dlp-enhanced-progress", extras = ["default"], specifier = "==2026.3.13.160948" },
 ]
 provides-extras = ["desktop", "dev"]
+
+[[package]]
+name = "websockets"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/52/748c014f07f4e0e170c8932de7e647a1511d5ab3049cd978797136aee577/websockets-16.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b6aa3f7ad345cf3862c21f4fbf2ef5e14d911348476c2845e137c091fe3a3f0b", size = 179798, upload-time = "2026-07-10T06:31:09.664Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5e/2a2e64d977d084e49d37c187c26c056daaff41965be7300cd5dbde6f8b07/websockets-16.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b43fcfb521ac2f34ba80b7b8ea16303e4ad82dd8af667bf40839ad3a5d37b164", size = 177478, upload-time = "2026-07-10T06:31:11.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/12/5b85b4e75d697e548a94962ce5c036b05dd21cb9545759d555c5586422fc/websockets-16.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2bd3e12cd9afbe2baedae0b1eeade8ba64329b60fe2f9abdc966bd10fd2c2ef5", size = 177746, upload-time = "2026-07-10T06:31:12.386Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/62/79b1c8f0cee0da648b4899e1c5b0dbd3aa59846985136a54854db6827ab4/websockets-16.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:35f41979c8623df9bd30d949d82010a8fda5c56ff12cd8508a5b7272b6d4b53a", size = 187345, upload-time = "2026-07-10T06:31:13.754Z" },
+    { url = "https://files.pythonhosted.org/packages/25/34/b7c5c52c2f24280e1c017acb7ad491a566750a5cceca7f3cf999373bba21/websockets-16.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a24d1f35aef07d794a16c853c688e74956c50239bec37b4f2de080056046419b", size = 188581, upload-time = "2026-07-10T06:31:15.075Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/37/604193bebcbeffe96fdf795960b83a15d600880c64dc17ec9c31c5b3427d/websockets-16.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0c64c024ddf7a35331b21fcddb562a039c275d2c82e8c2d12939e7da23997270", size = 191362, upload-time = "2026-07-10T06:31:16.395Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b4/5ee27575b367d7110d4d13945e2a9de067ec84dc71e54b87f01e38550d9a/websockets-16.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c3e99757f5baafe20fc598e202ea6f5b0b265186ad38d0a17bd8beca16296955", size = 189216, upload-time = "2026-07-10T06:31:17.776Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/3e2dcc78d85fc5d9d814895ce6d07d0dfacc0f6aaa1d151f2b8c8d772299/websockets-16.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:353f3bc6e058ac1ccab4b3588e8598837a8c04cfc8351233e6d523be675d844c", size = 187971, upload-time = "2026-07-10T06:31:19.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2f/cd271717b93d5ee19626cb5e38a85baab745c86e33db7c31a3ac729b31b8/websockets-16.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0352f5b38b40e857b6428d468fa21dbb4dd4a567d933c26d9831b4efe1b92f43", size = 185381, upload-time = "2026-07-10T06:31:20.665Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/6ad6f2f1426317b5001bd490534208c7360636b35bac1dec2e0c22bfc40e/websockets-16.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70bd789afab579602968c39f21cb925466505f3edff22f0ae852bca54978a4f9", size = 188015, upload-time = "2026-07-10T06:31:22.024Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6d/533733132ab4c07540efd4a8f0b9a435d3a5059b2f26cc476ace1abf7f45/websockets-16.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d0fb4b46f121eccd539353baebd1083a8767a9a351109453d1d1caecd1ba40c2", size = 186619, upload-time = "2026-07-10T06:31:23.376Z" },
+    { url = "https://files.pythonhosted.org/packages/08/73/16c059f3d73b3331eba10793704afa4faa9939234fb08ef7dca35794e8f0/websockets-16.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c14b6634af01541e4efe2954fd8f263386f7aa6d37c01e55dd8109fd17661452", size = 188497, upload-time = "2026-07-10T06:31:25.024Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/89/9a8fae7dd2acdcfb1a8844c29fe42b518a04b64fce38a0923b6290e452f1/websockets-16.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:a58532c49a851bcb481e58c1be23b315c17fe2fbbed509d75aeea12f543d2c15", size = 186051, upload-time = "2026-07-10T06:31:26.291Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/b240c7dd6a0e0c59c1f68377cc3015263521080c327c15f5e753c1f6d378/websockets-16.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4e969170c3b08e1d8dabd990fef1fa702c4233aeaabec33f871806e444f6a0e4", size = 187029, upload-time = "2026-07-10T06:31:27.605Z" },
+    { url = "https://files.pythonhosted.org/packages/50/35/524e3fac40e47d6fdcf6c4b2c95ef1bc8a97e01593c90eff86621df7b716/websockets-16.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ff9b000064b88787ba9f7a3cb2af2b68a658ca5aad76458a46469e7124b678a0", size = 187308, upload-time = "2026-07-10T06:31:28.927Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/56840cf62c8859af6ba22b9529da937332468c80f32b598753e8a66d3990/websockets-16.1-cp312-cp312-win32.whl", hash = "sha256:b9f5d83f80f4d7c4bba6d97f3755ac05850c784dce0fd2ab371c4e41172f53ff", size = 180161, upload-time = "2026-07-10T06:31:30.316Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ff/87eb9eb44cb62424a8d729834f2b0515a47e2669fabec29820268f4d50a1/websockets-16.1-cp312-cp312-win_amd64.whl", hash = "sha256:6852c9f653966c16109d3b6f31181fd734f7914927e3f0fa1117af7a18c9aa21", size = 180462, upload-time = "2026-07-10T06:31:31.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
+    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e6/da1dc11507f8118145a81c751fe0c77e5e1c11b8554496addb39389e2dc2/websockets-16.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f881fca0a45dd6789939bd6637cd98169b92f1c3fdc78262f2cb9ec2cb1f324e", size = 179833, upload-time = "2026-07-10T06:31:58.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ac/c0d46f62e31e232487b2c123bc3cfd9a4e45684ca7dc0c37f0987f29baae/websockets-16.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c379d5b207d3a7f0ba4c2e4602a895b0bcc63fb5f5371a4ae7fbddb03b672b", size = 177524, upload-time = "2026-07-10T06:31:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/33/abd966074b34a51e4f134e0aaed80f5a4a0a35163ea5ac58a1bc5a076d23/websockets-16.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98ab58a4faa72b46da0127ccc1931dcbfc0985b0778892300a092185910c4cbe", size = 177743, upload-time = "2026-07-10T06:32:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/30/646e47b8a8dff04e227bdab512e6dde60663a647eeac7bbd6edddd92bbc5/websockets-16.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e9c4e369fc181b2d41a99e01477215cecdc8546a39f7d41a59cc0a7065a0b09", size = 187474, upload-time = "2026-07-10T06:32:02.54Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/72/890ab9d77494af93ea65268230bfbc0a90ba789401ed7a44356a44785644/websockets-16.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0704df094b2d5fa7f6f410925a594c2a5c9a09167731a76292e5410934208209", size = 188717, upload-time = "2026-07-10T06:32:04.156Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/aa/baedbbaa6bf9ed6029617ed5e8976535bd805f483ca9b3484e7ad9ee08bf/websockets-16.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b22b1f4950f6ab7126623329c3b47b3b90a14c05db517f2db2a026ad6c928352", size = 190090, upload-time = "2026-07-10T06:32:05.822Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/d813ec94e18002571ef4959d87a630eff6e01b72a51bcb0832b75ae8c51a/websockets-16.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1ae4a686a662964a6671069f84f7f908cc3475e782227726b0c622c715962105", size = 189320, upload-time = "2026-07-10T06:32:07.223Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3c/8ec52a6662f3df64090fba28cd521d405d54759268d8e820477037e8c80d/websockets-16.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:856bdd638f8277f86465057bfdd4da097c73058fb0f9d2bd5baea29e2bf2d367", size = 188068, upload-time = "2026-07-10T06:32:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7f/f0ae6042b14f86fa5f996c6563ea4cf107adc036ccbedc9d4f418d0095f9/websockets-16.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9003a1fde1c21a322a3ca3fa0c4bda8c639da81dbc925162766086643b05ba87", size = 185493, upload-time = "2026-07-10T06:32:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ad/5ffc53af9939c49fd653d147fa5b8f78ced1f6bce6c49a7446860945b0ce/websockets-16.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e947b1f5fdab045174306e3916785bf3ed537648acc1549827c08c33b10953", size = 188141, upload-time = "2026-07-10T06:32:11.434Z" },
+    { url = "https://files.pythonhosted.org/packages/67/62/729206c0ee577a4db8eae6dd06e0eef725a1287c6df11b2ef831d003df31/websockets-16.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5dd0e666b5931c0509cf65714686a1c5126771e663a79ac5d40da4f58b1f9502", size = 186653, upload-time = "2026-07-10T06:32:12.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/86/e8806a99ec4589914f255e6b658853fe537bf359c05e6ba5762ad9c27917/websockets-16.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a0285df7925657ad65a65fb8dc330808bce082827538fd50ef45fa12d1fc5bca", size = 188614, upload-time = "2026-07-10T06:32:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/89/38/ac554e2fc6ff0b8deeff9798b92e7abd8f99e2bd9731532e7033de208220/websockets-16.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:82d1c2cab3c133e9d059b3a5420bed9376bd30e21c185c63dda4ddadf6ddda47", size = 186165, upload-time = "2026-07-10T06:32:15.626Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c5/4ef4d8e53342f94f3c49e1ae089b32c1e8b3878e15e0022c7708c647f351/websockets-16.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c39907f1eaf11f6277def65aa02d68f30576b693d0c1ca332aafa3caa723ac6d", size = 187119, upload-time = "2026-07-10T06:32:17.114Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/33/4788b1dd417bd97eeb2698af3b9df6775ac656f96e9987da0419a067602f/websockets-16.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45c5ea55446171949eb99fd34b771ceddd511ca21958d40d0197ced33159e5ee", size = 187411, upload-time = "2026-07-10T06:32:18.629Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/00d37aad6dc3244ce349e2864815362e50b3cfc00cac28d216db20efe40f/websockets-16.1-cp314-cp314-win32.whl", hash = "sha256:b8ef8b1c8d6bd029a475ac432e730fba2dfd456715d26c473e2a82291024b99c", size = 179822, upload-time = "2026-07-10T06:32:20.233Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/37/2a8cb0eaddee5eaebda47a90a3ba0898d1ce3d866b02a4857fea17d82e5b/websockets-16.1-cp314-cp314-win_amd64.whl", hash = "sha256:7358ff21632b5d062707f73e859c824f1c3807e73d8ca25e71caca7c4cdcf145", size = 180167, upload-time = "2026-07-10T06:32:21.749Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5a/262ad5fcaef4198997b165060f09a63f861e76939b1786ab546ccc3f8120/websockets-16.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d0f38f4c3e9b359e257c339c2cc1967ccaeedb102e57c1c986bdce4bf4f32268", size = 180166, upload-time = "2026-07-10T06:32:23.278Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/36377db690f4292826e4501a6dec2801dc55fd1cf0405923b04937e478df/websockets-16.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3c3d2cbd1602593bad49bd86fa3fbb25407d87a3b4bf8857c0ac5ac4914e1901", size = 177697, upload-time = "2026-07-10T06:32:25.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c7/07171abce1e39799a76f473608580fe98bd43a1230f5146159622c02bccf/websockets-16.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:36069b74671e7e667f48a7484249f84c45a825a134c8b1bdc01875d0daa10d79", size = 177902, upload-time = "2026-07-10T06:32:26.564Z" },
+    { url = "https://files.pythonhosted.org/packages/14/17/c831f48e250bc4749f57c00dcce73337c41cd32f6d59a64567b84e782601/websockets-16.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:587f83c2ce8a5d628e166384d77fa7f0ac69b9007d515ab442123e6615aa8da3", size = 187766, upload-time = "2026-07-10T06:32:27.981Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/2e/4dfe63e245b0ecfaf470cf082d25c6ce35808159135fd88c82653a6b11ab/websockets-16.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6db7972d52bc1b66cefe2246902e256cbaebc9ba8a45eac09343d7eb6671b2", size = 188939, upload-time = "2026-07-10T06:32:29.365Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e5/5faf65aebd9562f6b4bc473d24ce38cc56f84eb5f5bee66ed9b86733f93c/websockets-16.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e7d6014888a0632e1ed7a4095248bb3095232999447f2d83bfb1900987dd9ed9", size = 191081, upload-time = "2026-07-10T06:32:30.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cd/2634f2f2c0556c1aae6501ed6840019cc569dd6fdbcac6494378daea4dc0/websockets-16.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cb074d150e4ad2a77aa8a332c2be85f3f64f2681519d2570c1225c12c9821ff", size = 189513, upload-time = "2026-07-10T06:32:32.399Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/2c700b51196104f09715b326b1f092ed25326bdf79a03e00a4842e503743/websockets-16.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d19c9067e1fe9490f974bffbc0e443b80a7674c5efb4980c429cc00771f07c5a", size = 188240, upload-time = "2026-07-10T06:32:33.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/20/86283636e499a1a357fa9441f690ba34f255e731f2fea174132b3b762b57/websockets-16.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d440ff0c6c7469ad59c0a412c383c235935b43635e89425e3f6a0c36de90c31b", size = 185955, upload-time = "2026-07-10T06:32:35.279Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/d7fb734b0095d43bc7f1c9f68afd50adb4176e7e513403e8c70ad7daa4fa/websockets-16.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8613129a2533f08de24505e69a3e403cedaadae49abdb043c4d170ca71b7e4bd", size = 188491, upload-time = "2026-07-10T06:32:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/168a192689db468405ecf3b8e4a2c18811936b0724d017ad7e6d252734f0/websockets-16.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a5bf9c23f197b4ec88290fd5463f33db67362a1bb10f85fc2e8e7627f0ddab97", size = 186983, upload-time = "2026-07-10T06:32:38.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9b/66795fa91ebe49019ebe4fa910282172252e37046b80e08fc52e0c365150/websockets-16.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:520b0fd0395f075febb283c76755af724ab9fd19dffa4f3bfd18cb4e622790a3", size = 188890, upload-time = "2026-07-10T06:32:39.545Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/32/126bbc844be5afb3613fd43211dac10a9645f4cf39741d04acaa2ec7030c/websockets-16.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7143aa09a67e1c013be44e81a88dfe90fc6244198ab86c7edd064152cf619805", size = 186583, upload-time = "2026-07-10T06:32:41.038Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b9/0b5db9cbcf6e4970db4496893244a8d92e07f71a8ef27cf34b08aa02fef1/websockets-16.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:7acb811fad08e611755800d1560e395c67e11a6bd563598ea6abb319afb86938", size = 187353, upload-time = "2026-07-10T06:32:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/254b2131a10d831b76e2c18dfe7add9729c6292c674a8085bf8de01ad151/websockets-16.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c5cf88e3faa2f7931bc6baeee7599c97656a3f6ac7f831f4fccba233e141783a", size = 187784, upload-time = "2026-07-10T06:32:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/21/dc/e7288aa8e3ac5a88a0924619984d663c1abf2a87d0ea98290c66fdaee0ec/websockets-16.1-cp314-cp314t-win32.whl", hash = "sha256:589f8842521c8307684ce0b40ce4ad70c5e0aa46484c6f1225a94ef4b8970341", size = 179947, upload-time = "2026-07-10T06:32:45.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/de/37edf1260ff0fbbd2f82433489c4cfbe799ac2ff21355331609879329fe6/websockets-16.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c0e0857c30bbbc2bb5c30687508f0b7ec19aa026cd9f2ff8424d0fee42dcc07", size = 180291, upload-time = "2026-07-10T06:32:47.119Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
+]
 
 [[package]]
 name = "yt-dlp-ejs"
@@ -1054,9 +1231,22 @@ wheels = [
 
 [[package]]
 name = "yt-dlp-enhanced-progress"
-version = "2026.3.3"
+version = "2026.3.13.160948"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/35/42d5ce46e12154114d0e6dc6919752538e3c6bfa130354cd5853732929a6/yt_dlp_enhanced_progress-2026.3.3.tar.gz", hash = "sha256:cbe146c6eb016c1c5d3122336924bbbee423046029ca7c11fcc652718266690f", size = 2867764, upload-time = "2026-03-04T07:01:22.377Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/ef/009acade9d39669d2b4b389fc4c3af012fbad06b5751e4dec27222dfa63f/yt_dlp_enhanced_progress-2026.3.13.160948.tar.gz", hash = "sha256:7cfe5b5847380daa255f2af9a3e1d1e43db10dec6c363c3204704a900869a147", size = 3133011, upload-time = "2026-03-13T16:29:19.747Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/5c/82cc53ff3bdf488767e773c897825cef445730d129870e3896ac080f24bf/yt_dlp_enhanced_progress-2026.3.3-py3-none-any.whl", hash = "sha256:14410c82ec7a36953bc5c83958a04d8648f28c91dc72c40f6a2eed6ef746bff7", size = 3065344, upload-time = "2026-03-04T07:01:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/eb/19ef86203e691017f912a2fcd12620431f056f1e3bee3b8fa2c654ba417e/yt_dlp_enhanced_progress-2026.3.13.160948-py3-none-any.whl", hash = "sha256:61bae841837eaa4e4372198eee9228b974b6c24de2acb177ff9c84534bea5bc1", size = 3321447, upload-time = "2026-03-13T16:29:17.802Z" },
+]
+
+[package.optional-dependencies]
+default = [
+    { name = "brotli", marker = "implementation_name == 'cpython'" },
+    { name = "brotlicffi", marker = "implementation_name != 'cpython'" },
+    { name = "certifi" },
+    { name = "mutagen" },
+    { name = "pycryptodomex" },
+    { name = "requests" },
+    { name = "urllib3" },
+    { name = "websockets" },
+    { name = "yt-dlp-ejs" },
 ]


### PR DESCRIPTION
## What this fixes

**Windows could not install ffmpeg at all.** `extractall()` left the binary at `%LOCALAPPDATA%\video-dl\ffmpeg-master-latest-win64-gpl-shared\bin\ffmpeg.exe` while the app looked for `%LOCALAPPDATA%\video-dl\ffmpeg.exe`. Every clean Windows install downloaded 30 MB and then died on the "This error shouldn't happen" dialog. Covered by tests now.

**The shipped yt-dlp was missing its recommended dependencies.** `available_dependencies` reported only certifi, requests, sqlite3, urllib3 and yt_dlp_ejs: no mutagen (audio tagging), no Cryptodome (AES), no websockets, no brotli. The fork is now pulled with its `[default]` extra and pinned exactly, since yt-dlp is frozen into the binary at build time anyway.

**Two of the three published APKs were broken.** jniLibs were injected into `arm64-v8a` only, but `--split-per-abi` published three APKs and the release notes advertised all three. ffmpeg, aria2c and qjs only exist for aarch64, so we now publish the one APK that works.

**The auto-update channel could brick itself.** The tufup state store was restored from the previous release with `2>/dev/null` and a silent fresh-bootstrap fallback. A transient download failure reset the TUF snapshot and timestamp versions to 1, which every installed client rejects as a rollback, permanently. It now fails the release instead, and bootstrapping is an explicit opt-in.

## Reproducibility

Third-party binaries were floating on rolling tags whose assets get replaced in place. ffmpeg for Android is pinned to `autobuild-2026-06-15-18-44`, aria2c to `release-2.0.1` (checksum-verified, on desktop too, where it was pinned to a different release than the APK), QuickJS to a commit. `uv sync --locked` replaces four independent unpinned pip resolutions per release.

## Coverage

CI ran only on Linux while the flagship artifact is Windows, and PyInstaller only ever ran at tag time, after `release.sh` had already pushed the tag. Tests now run on all three OSes, the binary is frozen on every PR, and `--help` (which exits inside argparse, before any heavy import) is replaced by `--selftest`, which imports flet, tufup, yt_dlp, the GUI and the updater, and asserts yt-dlp's dependencies are present in the frozen binary.

Verified locally: 383 tests pass, ruff and mypy clean, and `dist/video-dl.exe --selftest` prints `selftest ok (yt-dlp 2026.03.13.160948)`.