### PR TITLE
Drop the yt-dlp fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ env:
   FFMPEG_ANDROID_TAG: autobuild-2026-06-15-18-44
   ARIA2_TAG: release-2.0.1
   QUICKJS_COMMIT: 04be246001599f5995fa2f2d8c91a0f198d3f34c
-  EJS_VERSION: "0.5.0"
+  # Must match the yt-dlp-ejs version yt-dlp resolves to in uv.lock: the solver
+  # library and the Python side are versioned together.
+  EJS_VERSION: "0.8.0"
 
 jobs:
   build:

--- a/core/aria2c_progress.py
+++ b/core/aria2c_progress.py
@@ -1,0 +1,251 @@
+"""Make yt-dlp report download progress while aria2c is doing the downloading.
+
+yt-dlp hands the download to aria2c and then simply waits for it to exit, so the
+download bar sits at zero for the whole download and jumps to 100% at the end.
+That matters here: video-dl sets aria2c as the external downloader for `http`,
+which yt-dlp also uses for `https`, so aria2c handles most downloads.
+
+aria2c can expose a JSON-RPC server. We give it a port and a secret, poll it while
+it runs, and feed what it reports into yt-dlp's normal progress hooks.
+
+Upstream carried a version of this until 2026-05-28, when it was deleted along
+with aria2c's m3u8/dash support (advisory GHSA-vx4q-3cr2-7cg2). We do not bring
+any of that back: no fragments, no manifests, just the single file download that
+video-dl actually asks aria2c for.
+
+Like core/ytdlp_patch.py, this reaches into yt-dlp and is guarded: if a seam has
+moved, install() logs and returns, downloads still work, the bar just does not
+move. tests/test_aria2c_progress.py checks the seams against the installed yt-dlp.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import json
+import logging
+import subprocess
+import time
+import uuid
+
+logger = logging.getLogger("videodl")
+
+_installed = False
+
+# How long to wait for aria2c's RPC server to accept a connection, and how long to
+# let it claim it has nothing to download before concluding it is wedged.
+_RPC_STARTUP_ATTEMPTS = 20
+_RPC_POLL_INTERVAL = 0.1
+_IDLE_TIMEOUT = 10
+
+
+def install() -> bool:
+    """Teach yt-dlp's aria2c downloader to report progress. Idempotent."""
+    global _installed
+    if _installed:
+        return True
+
+    try:
+        from yt_dlp.downloader import external as external_fd
+        from yt_dlp.utils import Popen, find_available_port, traverse_obj
+    except ImportError as e:
+        logger.warning(f"yt-dlp has moved: aria2c will download without progress ({e})")
+        return False
+
+    aria2c_class = getattr(external_fd, "Aria2cFD", None)
+    seams = ("_call_downloader", "_call_process", "_make_cmd", "_hook_progress")
+    if not aria2c_class or not all(hasattr(aria2c_class, seam) for seam in seams):
+        logger.warning("yt-dlp has moved: aria2c will download without progress")
+        return False
+
+    original_call_downloader = aria2c_class._call_downloader
+    original_call_process = aria2c_class._call_process
+    original_make_cmd = aria2c_class._make_cmd
+
+    def _call_downloader(self, tmpfilename, info_dict):
+        allocate_rpc(self, info_dict, find_available_port)
+        return original_call_downloader(self, tmpfilename, info_dict)
+
+    def _make_cmd(self, tmpfilename, info_dict):
+        return original_make_cmd(self, tmpfilename, info_dict) + rpc_flags(info_dict)
+
+    def _call_process(self, cmd, info_dict):
+        if "__rpc" not in info_dict:
+            return original_call_process(self, cmd, info_dict)
+        return _download_with_progress(self, cmd, info_dict, Popen, traverse_obj)
+
+    aria2c_class._call_downloader = _call_downloader
+    aria2c_class._make_cmd = _make_cmd
+    aria2c_class._call_process = _call_process
+    _installed = True
+    logger.debug("aria2c download progress installed")
+    return True
+
+
+def allocate_rpc(downloader, info_dict: dict, find_available_port) -> dict | None:
+    """Reserve a port and a secret for aria2c's RPC server, on the info dict.
+
+    Honours the same compat opt yt-dlp uses to turn external downloader progress
+    off. No free port means no progress, not a failed download.
+    """
+    if "no-external-downloader-progress" in downloader.params.get("compat_opts", []):
+        return None
+
+    port = find_available_port()
+    if not port:
+        return None
+
+    info_dict["__rpc"] = {"port": port, "secret": str(uuid.uuid4())}
+    return info_dict["__rpc"]
+
+
+def rpc_flags(info_dict: dict) -> list[str]:
+    """The aria2c flags that open the RPC server, if one was reserved.
+
+    Appended after everything else, so that neither yt-dlp's own pinned flags nor
+    a user's --downloader-args can take the port out from under us.
+    """
+    rpc = info_dict.get("__rpc")
+    if not rpc:
+        return []
+    return [
+        "--enable-rpc",
+        f"--rpc-listen-port={rpc['port']}",
+        f"--rpc-secret={rpc['secret']}",
+    ]
+
+
+def rpc_call(downloader, port: int, secret: str, method: str, params=()) -> object:
+    """One JSON-RPC call to the local aria2c. Raises ConnectionError on any failure."""
+    from yt_dlp.networking import Request
+
+    call_id = str(uuid.uuid4())
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": method,
+            "params": [f"token:{secret}", *params],
+        }
+    ).encode()
+
+    request = Request(
+        f"http://localhost:{port}/jsonrpc",
+        data=payload,
+        headers={"Content-Type": "application/json", "Content-Length": f"{len(payload)}"},
+        # aria2c is on localhost. Sending this through the user's proxy would fail.
+        proxies={"all": None},
+    )
+    try:
+        with downloader.ydl.urlopen(request) as response:
+            answer = json.load(response)
+    except Exception as e:
+        raise ConnectionError(f"aria2c RPC {method} failed: {e}") from e
+
+    if answer.get("id") != call_id:
+        raise ConnectionError("aria2c RPC answered a different call")
+    return answer["result"]
+
+
+def _download_with_progress(downloader, cmd, info_dict, popen_class, traverse_obj):
+    """Run aria2c, polling its RPC server, reporting into yt-dlp's progress hooks."""
+    rpc = info_dict["__rpc"]
+    call = functools.partial(rpc_call, downloader, rpc["port"], rpc["secret"])
+    started = time.time()
+
+    status = {
+        "filename": info_dict.get("_filename"),
+        "status": "downloading",
+        "elapsed": 0,
+        "downloaded_bytes": 0,
+    }
+
+    def stat(key, *sources, average=False):
+        values = tuple(float(v) for v in traverse_obj(sources, (..., ..., key)) if v is not None) or (0,)
+        return sum(values) / (len(values) if average else 1)
+
+    with popen_class(cmd, text=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE) as process:
+        if not _wait_for_rpc(downloader, call, process):
+            _, stderr = process.communicate()
+            return "", stderr, process.returncode
+
+        try:
+            downloader._hook_progress(status, info_dict)
+            returncode = process.poll()
+            idle_since = None
+
+            while returncode is None:
+                try:
+                    # https://aria2.github.io/manual/en/html/aria2c.html#aria2.tellActive
+                    active = call("aria2.tellActive")
+                    done = call("aria2.tellStopped", [0, 1])
+                except ConnectionError:
+                    # The download itself is still going. Let it finish, just blind.
+                    downloader.to_screen("[aria2c] RPC connection lost, waiting for the download to finish")
+                    _, stderr = process.communicate()
+                    return "", stderr, process.returncode
+
+                downloaded = stat("totalLength", done) + stat("completedLength", active)
+                speed = stat("downloadSpeed", active)
+                total = stat("totalLength", active, done, average=True)
+                if total < downloaded:
+                    total = 0
+
+                status.update(
+                    {
+                        "downloaded_bytes": int(downloaded),
+                        "speed": speed or None,
+                        "total_bytes": total or None,
+                        "total_bytes_estimate": total or None,
+                        "eta": (total - downloaded) / speed if total and speed else None,
+                        "elapsed": time.time() - started,
+                    }
+                )
+                downloader._hook_progress(status, info_dict)
+
+                if not active and done:
+                    with contextlib.suppress(ConnectionError):
+                        call("aria2.shutdown")
+                    returncode = process.wait()
+                    break
+
+                # Nothing active and nothing finished means aria2c is wedged. Without
+                # this it would sit there and the download would hang forever.
+                if not active and not done:
+                    idle_since = idle_since or time.time()
+                    if time.time() - idle_since > _IDLE_TIMEOUT:
+                        downloader.to_screen("[aria2c] RPC reports no download at all, shutting it down")
+                        with contextlib.suppress(ConnectionError):
+                            call("aria2.shutdown")
+                        returncode = process.wait()
+                        break
+                else:
+                    idle_since = None
+
+                time.sleep(_RPC_POLL_INTERVAL)
+                returncode = process.poll()
+        except Exception:
+            # Including the cancel path: never leave an orphan aria2c behind.
+            process.kill()
+            process.wait()
+            raise
+
+        _, stderr = process.communicate()
+        return "", stderr, returncode
+
+
+def _wait_for_rpc(downloader, call, process) -> bool:
+    """Poll aria2c's RPC server until it answers. False means carry on without progress."""
+    for attempt in range(_RPC_STARTUP_ATTEMPTS):
+        if process.poll() is not None:
+            downloader.to_screen(f"[aria2c] exited immediately with code {process.returncode}")
+            return False
+        try:
+            call("aria2.getVersion")
+            return True
+        except ConnectionError:
+            downloader.write_debug(f"[aria2c] waiting for the RPC server ({attempt + 1}/{_RPC_STARTUP_ATTEMPTS})")
+            time.sleep(_RPC_POLL_INTERVAL)
+
+    downloader.to_screen("[aria2c] RPC server never came up, downloading without progress")
+    return False

--- a/core/download.py
+++ b/core/download.py
@@ -15,6 +15,7 @@ from yt_dlp.postprocessor import FFmpegPostProcessor
 from yt_dlp.utils import DownloadCancelled as YtdlpDownloadCancelled
 
 import runtime
+from core import aria2c_progress, ytdlp_patch
 from core.callbacks import CancelToken, ProgressCallback, StatusCallback
 from core.config_types import DownloadConfig
 from core.encode import post_process_dl
@@ -71,6 +72,8 @@ def create_ydl(
 ) -> YoutubeDL:
     """Create a reusable YoutubeDL instance (cookies extracted once)."""
     logger.debug("ydl options %s", ydl_opts)
+    ytdlp_patch.install()
+    aria2c_progress.install()
     ydl_opts["logger"] = _YdlUiLogger(status_cb)
     ffmpeg_path = ff_path.get("ffmpeg", "ffmpeg")
     if ffmpeg_path != "ffmpeg":

--- a/core/encode.py
+++ b/core/encode.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import subprocess
 from typing import TYPE_CHECKING
 
-from yt_dlp.postprocessor.ffmpeg import FFmpegProgressTracker
-
+from core.ffmpeg_progress import FFmpegProgressTracker
 from core.hwaccel import fastest_encoder
 from i18n.lang import GuiField, get_text
 
@@ -249,14 +247,6 @@ def _ffmpeg_video(
     os.rename(src=tmp_path, dst=os.path.splitext(path)[0] + new_ext)
 
 
-class _MinimalYDL:
-    """Minimal ydl stub so FFmpegProgressTracker enables progress tracking."""
-
-    @staticmethod
-    def write_debug(msg):
-        logging.debug(msg)
-
-
 def _progress_ffmpeg(
     cmd: list,
     action: str,
@@ -266,7 +256,7 @@ def _progress_ffmpeg(
     duration: int,
 ) -> None:
     """
-    Run ffmpeg with progress tracking using FFmpegProgressTracker.
+    Run ffmpeg with progress tracking.
 
     Args:
         cmd: FFmpeg command arguments (must include -progress pipe:1)
@@ -276,35 +266,32 @@ def _progress_ffmpeg(
         progress_cb: Progress callback
         duration: File duration in seconds (already probed)
     """
-    filesize = os.path.getsize(filepath)
-    info_dict = {
-        "duration": duration,
-        "filesize": filesize,
-    }
 
-    def hook(status, info):
+    def hook(status: dict) -> None:
         if cancel.is_cancelled():
-            proc = tracker.ffmpeg_proc
+            proc = tracker.proc
             if proc and proc.poll() is None:
                 try:
+                    # Asking ffmpeg to quit leaves a readable file behind, killing it
+                    # does not. Fall back to the kill only if ffmpeg will not listen.
+                    assert proc.stdin is not None
                     proc.stdin.write("q")
                     proc.stdin.flush()
                 except Exception:
                     proc.kill()
             return
-        status["processed_bytes"] = status.get("outputted", 0)
         status["action"] = action
         progress_cb.on_process_progress(status)
 
     tracker = FFmpegProgressTracker(
-        info_dict,
         cmd,
         hook,
-        ydl=_MinimalYDL(),
+        duration=duration,
+        total_bytes=os.path.getsize(filepath),
+        filename=cmd[-1],
         stdin=subprocess.PIPE,
-        output_filename=cmd[-1],
     )
-    _, stderr, retcode = tracker.run_ffmpeg_subprocess()
+    _, stderr, retcode = tracker.run()
     if cancel.is_cancelled():
         return
     if retcode != 0:

--- a/core/ffmpeg_progress.py
+++ b/core/ffmpeg_progress.py
@@ -1,0 +1,282 @@
+"""Run an ffmpeg command and report its progress.
+
+ffmpeg writes a machine readable progress report to the pipe named by
+``-progress``, one ``key=value`` per line, ending each block with ``progress=``.
+This parses that stream and calls back with the same status shape the GUI's
+process bar consumes: ``processed_bytes`` out of ``total_bytes``.
+
+ffmpeg reports how far it has got in *time*, never in bytes, so the byte counts
+here are that time ratio applied to the input size. They are honest enough for a
+progress bar and are not to be trusted for anything else.
+
+This used to live in a fork of yt-dlp. It never needed to: it takes an argument
+list, runs a subprocess and parses stdout. See core/ytdlp_patch.py for the part
+that teaches yt-dlp's own postprocessors to report through it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from queue import Empty, Queue
+from threading import Thread
+
+logger = logging.getLogger("videodl")
+
+ProgressHook = Callable[[dict], None]
+
+# One report block, as written by `-progress pipe:1`. The frame/fps/quality lines
+# only appear when a video stream is being encoded.
+_PROGRESS_BLOCK = re.compile(
+    r"""(?x)
+    (?:
+        frame=\s*(?P<frame>\S+)\n
+        fps=\s*(?P<fps>\S+)\n
+        (?:stream_\d+_\d+_q=\s*\S+\n)+
+    )?
+    bitrate=\s*(?P<bitrate>\S+)\n
+    total_size=\s*(?P<total_size>\S+)\n
+    out_time_us=\s*(?P<out_time_us>\S+)\n
+    out_time_ms=\s*(?P<out_time_ms>\S+)\n
+    out_time=\s*(?P<out_time>\S+)\n
+    dup_frames=\s*(?P<dup_frames>\S+)\n
+    drop_frames=\s*(?P<drop_frames>\S+)\n
+    speed=\s*(?P<speed>\S+)\n
+    progress=\s*(?P<progress>\S+)
+    """
+)
+
+_TIME_WITH_UNIT = re.compile(r"(?P<value>\d+)(?P<unit>[mu]?s)")
+# [[HH:]MM:]SS, so `1:30` is a minute and a half, not an hour and thirty seconds.
+# The hours group only exists when a minutes group follows it.
+_TIME_HMS = re.compile(r"(?:(?:(?P<hours>\d+):)?(?P<minutes>\d+):)?(?P<seconds>\d+)(\.(?P<fraction>\d+))?")
+_BITRATE = re.compile(r"(?P<value>\d+)(\.(?P<fraction>\d+))?(?P<prefix>[gmk])?bits/s")
+
+_SEEK_FLAGS = ("-ss", "-sseof", "-to", "-t")
+
+
+def ffmpeg_time_to_seconds(value: str) -> float:
+    """Parse any of the time formats ffmpeg accepts: `12`, `1:02:03.5`, `500ms`, `900us`."""
+    with_unit = _TIME_WITH_UNIT.fullmatch(value)
+    if with_unit:
+        seconds = float(with_unit.group("value"))
+        unit = with_unit.group("unit")
+        if unit == "ms":
+            return seconds / 1_000
+        if unit == "us":
+            return seconds / 1_000_000
+        return seconds
+
+    hms = _TIME_HMS.fullmatch(value)
+    if not hms:
+        return 0.0
+
+    seconds = float(hms.group("seconds"))
+    if hms.group("hours"):
+        seconds += 3600 * int(hms.group("hours"))
+    if hms.group("minutes"):
+        seconds += 60 * int(hms.group("minutes"))
+    if hms.group("fraction"):
+        fraction = hms.group("fraction")
+        seconds += int(fraction) / (10 ** len(fraction))
+    return seconds
+
+
+def bitrate_to_bits_per_second(value: str) -> float:
+    """Parse ffmpeg's `bitrate=` field, e.g. `1234.5kbits/s`. Returns 0 when ffmpeg reports `N/A`."""
+    match = _BITRATE.fullmatch(value)
+    if not match:
+        return 0.0
+
+    bitrate = float(match.group("value"))
+    if match.group("fraction"):
+        fraction = match.group("fraction")
+        bitrate += int(fraction) / (10 ** len(fraction))
+
+    multiplier = {"g": 1_000_000_000, "m": 1_000_000, "k": 1_000}.get(match.group("prefix") or "", 1)
+    return bitrate * multiplier
+
+
+def duration_to_process(args: list[str], duration: float) -> float:
+    """How much of the media the command will actually touch, given its seek flags.
+
+    A command that trims with `-ss 60 -to 90` processes 30 seconds, not the whole
+    file, and its progress must be measured against those 30 seconds.
+    """
+    if not duration:
+        return 0.0
+
+    start, end, explicit = 0.0, duration, None
+    for i, arg in enumerate(args[:-1]):
+        flag, _, inline_value = arg.partition("=")
+        if flag not in _SEEK_FLAGS:
+            continue
+        timestamp = ffmpeg_time_to_seconds(inline_value or args[i + 1])
+        if flag == "-ss":
+            start = timestamp
+        elif flag == "-sseof":
+            start = end - timestamp
+        elif flag == "-to":
+            end = timestamp
+        elif flag == "-t":
+            explicit = timestamp
+
+    processed = explicit if explicit is not None else end - start
+    return processed if processed >= 0 else 0.0
+
+
+class FFmpegProgressTracker:
+    """Run `args` to completion, calling `on_progress` with a status dict as it goes.
+
+    `duration` and `total_bytes` describe the *input*: the media duration in
+    seconds and its size on disk. Without a duration ffmpeg's output cannot be
+    turned into a ratio, so the command still runs, it just reports no progress.
+    """
+
+    def __init__(
+        self,
+        args: list[str],
+        on_progress: ProgressHook,
+        *,
+        duration: float = 0,
+        total_bytes: int = 0,
+        filename: str = "",
+        stdin: int | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        # Without this ffmpeg reports nothing on stdout and the bar never moves,
+        # which is too easy for a caller to forget. Guarantee it here.
+        self._args = args if "-progress" in args else [*args, "-progress", "pipe:1"]
+        self._on_progress = on_progress
+        self._stdin = stdin
+        self._env = env
+
+        self._duration = duration_to_process(args, duration)
+        # The output covers only the part of the input being processed.
+        self._total_bytes = int(total_bytes * self._duration / duration) if duration else 0
+
+        self._stdout_queue: Queue[str] = Queue()
+        self._stderr_queue: Queue[str] = Queue()
+        self._stdout = ""
+        self._stderr = ""
+        self._block = ""
+        self._started_at = 0.0
+        self._status: dict = {
+            "filename": filename,
+            "status": "processing",
+            "elapsed": 0,
+            "processed_bytes": 0,
+            "total_bytes": self._total_bytes,
+        }
+        self.proc: subprocess.Popen | None = None
+
+    def run(self) -> tuple[str, str, int]:
+        """Run ffmpeg to completion. Returns (stdout, stderr, returncode)."""
+        self.proc = subprocess.Popen(
+            self._args,
+            text=True,
+            encoding="utf8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=self._stdin,
+            env=self._env,
+        )
+        self._started_at = time.time()
+
+        readers = [
+            Thread(target=self._drain, args=(self.proc.stdout, self._stdout_queue), daemon=True),
+            Thread(target=self._drain, args=(self.proc.stderr, self._stderr_queue), daemon=True),
+        ]
+        for reader in readers:
+            reader.start()
+
+        returncode = self._wait()
+
+        for reader in readers:
+            reader.join(timeout=5)
+        self._consume_queues()
+
+        if sys.platform == "win32":
+            # Give Windows a moment to release the handles on the output file,
+            # which the caller is about to rename.
+            time.sleep(0.5)
+
+        return self._stdout, self._stderr, returncode
+
+    @staticmethod
+    def _drain(stream, queue: Queue[str]) -> None:
+        """Read a pipe to EOF from its own thread.
+
+        ffmpeg writes progress to stdout and its log to stderr. Reading them
+        one after the other in a single thread deadlocks as soon as the pipe
+        we are not reading fills up.
+        """
+        for line in iter(stream.readline, ""):
+            queue.put(line.rstrip())
+        stream.close()
+
+    def _wait(self) -> int:
+        assert self.proc is not None
+        returncode = self.proc.poll()
+        while returncode is None:
+            time.sleep(0.05)
+            self._consume_queues()
+            self._status["elapsed"] = time.time() - self._started_at
+            self._on_progress(self._status.copy())
+            returncode = self.proc.poll()
+        return returncode
+
+    def _consume_queues(self) -> None:
+        while True:
+            try:
+                self._block += self._stdout_queue.get_nowait() + "\n"
+            except Empty:
+                break
+            self._parse_block()
+
+        while True:
+            try:
+                line = self._stderr_queue.get_nowait()
+            except Empty:
+                break
+            self._stderr += line + "\n"
+            if line.strip():
+                logger.debug(f"ffmpeg: {line}")
+
+    def _parse_block(self) -> None:
+        report = _PROGRESS_BLOCK.match(self._block)
+        if not report:
+            return
+
+        self._stdout += self._block
+        self._block = ""
+
+        # ffmpeg's own total_size is unreliable and can push the bar past 100%.
+        # Derive the byte count from how far into the media it has got instead.
+        out_time = int(report.group("out_time_us") or 0) // 1_000_000
+        processed = int(out_time / self._duration * self._total_bytes) if self._duration else 0
+        speed = bitrate_to_bits_per_second(report.group("bitrate"))
+
+        self._status.update(
+            {
+                "processed_bytes": processed,
+                "speed": speed or None,
+                "eta": self._eta(report.group("speed"), out_time),
+            }
+        )
+        self._on_progress(self._status.copy())
+
+    def _eta(self, speed_field: str, out_time: int) -> float | None:
+        """`speed=` is a multiple of realtime, e.g. `2.5x`, so the remaining media time over it."""
+        if not self._duration:
+            return None
+        try:
+            speed = float(speed_field.rstrip("x"))
+            return (self._duration - out_time) / speed
+        except (TypeError, ValueError, ZeroDivisionError):
+            return None

--- a/core/ytdlp_patch.py
+++ b/core/ytdlp_patch.py
@@ -1,0 +1,140 @@
+"""Teach yt-dlp's ffmpeg postprocessors to report progress.
+
+yt-dlp runs ffmpeg for the operations it owns: merging video and audio,
+extracting audio, cutting SponsorBlock segments, trimming to a range. Upstream
+reports none of it, so the GUI's process bar sits frozen through operations that
+can take minutes.
+
+video-dl used to solve this with a fork of yt-dlp, which meant republishing the
+whole project to PyPI on a cron and shipping a yt-dlp that was months behind
+upstream. Everything that fork changed on the ffmpeg side is replaced here by
+one interception, on top of three things upstream already offers:
+
+  FFmpegPostProcessor.real_run_ffmpeg   the one call that runs an ffmpeg command
+  PostProcessor._hook_progress          already routed to `postprocessor_hooks`
+  FFmpegPostProcessor.get_metadata_object   ffprobe, for the duration
+
+We deliberately do not rebuild yt-dlp's ffmpeg command line: the wrapper lets
+upstream build it, and swaps only the call that runs it. Whatever flags upstream
+adds or fixes, we inherit.
+
+This reaches into yt-dlp's internals, so it is guarded: if any seam it needs has
+moved, install() logs and returns, yt-dlp keeps working, and the process bar just
+does not move. tests/test_ytdlp_patch.py asserts the seams against the installed
+yt-dlp, so a yt-dlp bump that breaks this fails CI instead of failing users.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import threading
+from typing import Any, cast
+
+from core.ffmpeg_progress import FFmpegProgressTracker
+
+logger = logging.getLogger("videodl")
+
+_installed = False
+
+# yt-dlp's own Popen, kept so the shim can fall back to it and so tests can assert
+# the shim is really a subclass of it rather than a lookalike.
+_ORIGINAL_POPEN: type | None = None
+
+# Set only for the duration of one real_run_ffmpeg call, on the thread making it,
+# so the Popen shim below knows it is running an ffmpeg command we want to follow
+# rather than, say, the ffprobe call that measured the duration.
+_current: threading.local = threading.local()
+
+
+class _Context:
+    def __init__(self, pp, duration: float, total_bytes: int, filename: str) -> None:
+        self.pp = pp
+        self.duration = duration
+        self.total_bytes = total_bytes
+        self.filename = filename
+
+
+def install() -> bool:
+    """Wrap yt-dlp's ffmpeg execution so postprocessors report progress. Idempotent."""
+    global _installed, _ORIGINAL_POPEN
+    if _installed:
+        return True
+
+    from yt_dlp.postprocessor import ffmpeg as ffmpeg_pp
+
+    pp_class = getattr(ffmpeg_pp, "FFmpegPostProcessor", None)
+    original_run = getattr(pp_class, "real_run_ffmpeg", None)
+    popen_class = cast(Any, getattr(ffmpeg_pp, "Popen", None))
+
+    if not (pp_class and original_run and popen_class and hasattr(pp_class, "_hook_progress")):
+        logger.warning("yt-dlp has moved: ffmpeg postprocessing will run without progress")
+        return False
+
+    def real_run_ffmpeg(self, input_path_opts, output_path_opts, *, expected_retcodes=(0,)):
+        inputs = [path for path, _ in input_path_opts if path]
+        output = next((path for path, _ in output_path_opts if path), "")
+        _current.context = _Context(self, *_measure(self, inputs), filename=output)
+        try:
+            return original_run(self, input_path_opts, output_path_opts, expected_retcodes=expected_retcodes)
+        finally:
+            _current.context = None
+
+    class _ProgressPopen(popen_class):  # type: ignore[misc, valid-type]
+        """Stands in for yt-dlp's Popen inside the ffmpeg postprocessor module.
+
+        Only `run` is overridden, and only when a real_run_ffmpeg call is in
+        flight on this thread. Every other use of Popen in that module, ffprobe
+        included, behaves exactly as before.
+        """
+
+        @classmethod
+        def run(cls, args, *pargs, **kwargs):
+            context = getattr(_current, "context", None)
+            if context is None or not context.duration:
+                return popen_class.run(args, *pargs, **kwargs)
+            return _run_with_progress(context, list(args), kwargs.get("stdin"), kwargs.get("env"))
+
+    pp_class.real_run_ffmpeg = real_run_ffmpeg
+    ffmpeg_pp.Popen = _ProgressPopen
+    _ORIGINAL_POPEN = popen_class
+    _installed = True
+    logger.debug("ffmpeg postprocessing progress installed")
+    return True
+
+
+def _measure(pp, inputs: list[str]) -> tuple[float, int]:
+    """Duration in seconds and size in bytes of what ffmpeg is about to read."""
+    total_bytes = 0
+    duration = 0.0
+    for path in inputs:
+        with contextlib.suppress(OSError):
+            total_bytes += os.path.getsize(path)
+        if duration:
+            continue
+        try:
+            metadata = pp.get_metadata_object(path)
+            duration = float(metadata.get("format", {}).get("duration") or 0)
+        except Exception as e:
+            # An unreadable duration only costs the progress bar, so never raise.
+            logger.debug(f"could not probe {path} for its duration: {e}")
+    return duration, total_bytes
+
+
+def _run_with_progress(context: _Context, args: list[str], stdin, env) -> tuple[str, str, int]:
+    """Run one ffmpeg command, reporting to the postprocessor's progress hooks."""
+
+    def on_progress(status: dict) -> None:
+        context.pp._hook_progress(status, {})
+
+    tracker = FFmpegProgressTracker(
+        args,
+        on_progress,
+        duration=context.duration,
+        total_bytes=context.total_bytes,
+        filename=context.filename,
+        stdin=stdin,
+        env=env,
+    )
+    return tracker.run()

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ def selftest() -> None:
     from yt_dlp.dependencies import available_dependencies
     from yt_dlp.version import __version__ as yt_dlp_version
 
+    from core import aria2c_progress, ytdlp_patch
     from core.download import download  # noqa: F401
     from gui.app import videodl_gui  # noqa: F401
     from sys_vars import init_paths  # noqa: F401
@@ -36,6 +37,13 @@ def selftest() -> None:
     missing = _REQUIRED_YT_DLP_DEPS - set(available_dependencies)
     if missing:
         raise SystemExit(f"yt-dlp is missing dependencies: {', '.join(sorted(missing))}")
+
+    # Both reach into yt-dlp's internals to report progress. They fail soft at
+    # runtime, so this is the place that makes a yt-dlp bump that broke them loud.
+    if not ytdlp_patch.install():
+        raise SystemExit("the ffmpeg progress patch no longer applies to this yt-dlp")
+    if not aria2c_progress.install():
+        raise SystemExit("the aria2c progress patch no longer applies to this yt-dlp")
 
     print(f"selftest ok (yt-dlp {yt_dlp_version})")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,17 @@ dependencies = [
     "flet>=0.81",
     "quantiphy",
     "tomlkit",
-    # Our yt-dlp fork, republished under this name. Pinned exactly: yt-dlp is
-    # frozen into the binary at build time anyway, so a floating spec buys no
-    # fixes for users, it only makes two builds of the same tag differ. Bump it
-    # deliberately when the fork republishes.
+    # Upstream yt-dlp, not a fork. ffmpeg progress reporting, the one thing the
+    # fork existed for, is done at runtime in core/ytdlp_patch.py instead.
     #
     # [default] pulls yt-dlp's own recommended runtime deps (mutagen for audio
     # tagging, websockets, pycryptodomex, brotli, certifi, yt-dlp-ejs). Without
     # it the shipped yt-dlp silently loses those code paths.
-    "yt-dlp-enhanced-progress[default]==2026.3.13.160948",
+    #
+    # Pinned exactly: yt-dlp is frozen into the binary at build time anyway, so a
+    # floating spec buys users no fixes, it only makes two builds of the same tag
+    # differ. Bump it deliberately, and often: a stale yt-dlp is a broken YouTube.
+    "yt-dlp[default]==2026.7.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_aria2c_progress.py
+++ b/tests/test_aria2c_progress.py
@@ -1,0 +1,221 @@
+import inspect
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# tests/test_download.py leaves MagicMocks in place of the yt_dlp package tree.
+# This module has to see the real thing: it exists to check our assumptions
+# against the yt-dlp that is actually installed.
+for _name in [
+    name for name, mod in list(sys.modules.items()) if name.startswith("yt_dlp") and isinstance(mod, MagicMock)
+]:
+    del sys.modules[_name]
+
+from yt_dlp.downloader.external import Aria2cFD, ExternalFD  # noqa: E402
+
+from core import aria2c_progress  # noqa: E402
+from core.aria2c_progress import _download_with_progress  # noqa: E402
+
+
+def _fake_process(poll_sequence, returncode=0):
+    """A Popen whose poll() follows a script, then keeps repeating its last answer.
+
+    A process that has exited stays exited, one that is still running stays
+    running. Handing poll() a fixed list instead makes the test encode exactly how
+    many times the downloader happens to call it, and it breaks the day it calls
+    it once more.
+    """
+    answers = iter(poll_sequence)
+    last = None
+
+    def poll():
+        nonlocal last
+        last = next(answers, last)
+        return last
+
+    process = MagicMock()
+    process.__enter__ = MagicMock(return_value=process)
+    process.__exit__ = MagicMock(return_value=False)
+    process.poll = MagicMock(side_effect=poll)
+    process.returncode = returncode
+    process.wait = MagicMock(return_value=returncode)
+    process.communicate = MagicMock(return_value=("", ""))
+    return process
+
+
+def _popen_returning(process):
+    return MagicMock(return_value=process)
+
+
+def _downloader():
+    downloader = MagicMock()
+    downloader.params = {}
+    return downloader
+
+
+def _active(completed, total, speed=50_000):
+    return [{"completedLength": str(completed), "totalLength": str(total), "downloadSpeed": str(speed)}]
+
+
+def _done(total):
+    return [{"totalLength": str(total), "completedLength": str(total)}]
+
+
+class TestSeams:
+    """Guard the yt-dlp internals core/aria2c_progress.py reaches into."""
+
+    def test_aria2c_still_exposes_the_methods_we_wrap(self):
+        for seam in ("_call_downloader", "_call_process", "_make_cmd", "_hook_progress"):
+            assert hasattr(Aria2cFD, seam), f"Aria2cFD.{seam} is gone"
+
+    def test_call_process_still_has_the_signature_we_replace(self):
+        params = inspect.signature(ExternalFD._call_process).parameters
+        assert list(params) == ["self", "cmd", "info_dict"]
+
+    def test_the_utils_we_borrow_are_still_there(self):
+        from yt_dlp.networking import Request  # noqa: F401
+        from yt_dlp.utils import Popen, find_available_port, traverse_obj  # noqa: F401
+
+
+class TestInstall:
+    def test_is_idempotent(self):
+        assert aria2c_progress.install()
+        patched = Aria2cFD._call_process
+        assert aria2c_progress.install()
+        assert Aria2cFD._call_process is patched
+
+    def test_allocates_an_rpc_endpoint_and_passes_it_to_aria2c(self):
+        from yt_dlp.utils import find_available_port
+
+        downloader = _downloader()
+        info_dict = {"url": "https://example.com/video.mp4"}
+
+        rpc = aria2c_progress.allocate_rpc(downloader, info_dict, find_available_port)
+
+        assert rpc and rpc["port"] and rpc["secret"]
+        assert info_dict["__rpc"] is rpc
+
+        flags = aria2c_progress.rpc_flags(info_dict)
+        assert flags == ["--enable-rpc", f"--rpc-listen-port={rpc['port']}", f"--rpc-secret={rpc['secret']}"]
+
+    def test_respects_the_compat_opt_that_turns_progress_off(self):
+        from yt_dlp.utils import find_available_port
+
+        downloader = _downloader()
+        downloader.params = {"compat_opts": {"no-external-downloader-progress"}}
+        info_dict = {"url": "https://example.com/video.mp4"}
+
+        assert aria2c_progress.allocate_rpc(downloader, info_dict, find_available_port) is None
+        assert "__rpc" not in info_dict
+        assert aria2c_progress.rpc_flags(info_dict) == []
+
+    def test_no_free_port_costs_the_bar_not_the_download(self):
+        downloader = _downloader()
+        info_dict = {"url": "https://example.com/video.mp4"}
+
+        assert aria2c_progress.allocate_rpc(downloader, info_dict, lambda: None) is None
+        assert "__rpc" not in info_dict
+
+
+class TestProgressReporting:
+    def setup_method(self):
+        from yt_dlp.utils import traverse_obj
+
+        self.traverse_obj = traverse_obj
+        self.info_dict = {"_filename": "video.mp4", "__rpc": {"port": 6800, "secret": "s3cret"}}
+
+    def _run(self, downloader, process, rpc):
+        with patch.object(aria2c_progress, "rpc_call", side_effect=rpc):
+            return _download_with_progress(
+                downloader, ["aria2c"], self.info_dict, _popen_returning(process), self.traverse_obj
+            )
+
+    def test_reports_progress_while_aria2c_downloads(self):
+        downloader = _downloader()
+        reports = []
+        downloader._hook_progress.side_effect = lambda status, info: reports.append(dict(status))
+
+        answers = [
+            None,  # getVersion, the readiness check
+            _active(100_000, 1_000_000),
+            [],
+            _active(500_000, 1_000_000),
+            [],
+            [],  # nothing active,
+            _done(1_000_000),  # and one finished: the download is over
+            None,  # shutdown
+        ]
+        _, _, returncode = self._run(downloader, _fake_process([None, None, None]), answers)
+
+        assert returncode == 0
+        progressed = [r for r in reports if r["downloaded_bytes"] > 0]
+        assert [r["downloaded_bytes"] for r in progressed] == [100_000, 500_000, 1_000_000]
+        assert progressed[0]["total_bytes"] == 1_000_000
+        assert progressed[0]["speed"] == 50_000
+        assert progressed[0]["eta"] == pytest.approx((1_000_000 - 100_000) / 50_000)
+        assert progressed[0]["status"] == "downloading"
+
+    def test_downloads_anyway_when_the_rpc_server_never_answers(self):
+        downloader = _downloader()
+        rpc = [ConnectionError("refused")] * aria2c_progress._RPC_STARTUP_ATTEMPTS
+
+        with patch("time.sleep"):
+            _, _, returncode = self._run(downloader, _fake_process([None]), rpc)
+
+        assert returncode == 0
+        downloader._hook_progress.assert_not_called()
+        assert any("without progress" in str(c) for c in downloader.to_screen.call_args_list)
+
+    def test_surfaces_an_aria2c_that_dies_on_startup(self):
+        downloader = _downloader()
+        _, _, returncode = self._run(downloader, _fake_process([1], returncode=1), [ConnectionError("refused")])
+
+        assert returncode == 1
+        downloader._hook_progress.assert_not_called()
+
+    def test_lets_the_download_finish_when_the_rpc_dies_mid_way(self):
+        downloader = _downloader()
+        reports = []
+        downloader._hook_progress.side_effect = lambda status, info: reports.append(dict(status))
+
+        answers = [None, ConnectionError("gone")]
+        _, _, returncode = self._run(downloader, _fake_process([None, None]), answers)
+
+        assert returncode == 0
+        assert len(reports) == 1, "only the initial report, then it goes blind but does not crash"
+        assert any("connection lost" in str(c) for c in downloader.to_screen.call_args_list)
+
+    def test_gives_no_eta_when_the_size_is_unknown(self):
+        downloader = _downloader()
+        reports = []
+        downloader._hook_progress.side_effect = lambda status, info: reports.append(dict(status))
+
+        answers = [
+            None,
+            [{"completedLength": "100", "totalLength": "0", "downloadSpeed": "0"}],
+            [],
+            [],
+            _done(100),
+            None,
+        ]
+        self._run(downloader, _fake_process([None, None]), answers)
+
+        assert reports[1]["eta"] is None
+        assert reports[1]["total_bytes"] is None
+        assert reports[1]["speed"] is None
+
+    def test_shuts_down_an_aria2c_that_reports_nothing_at_all(self):
+        """Without this the download hangs until the user kills the app."""
+        downloader = _downloader()
+        clock = iter([0, 0, 1, _IDLE := aria2c_progress._IDLE_TIMEOUT + 2])
+
+        answers = [None, [], [], [], [], [], [], None]
+        process = _fake_process([None, None, None])
+
+        with patch("time.sleep"), patch("time.time", side_effect=lambda: next(clock, 100)):
+            _, _, returncode = self._run(downloader, process, answers)
+
+        assert returncode == 0
+        process.wait.assert_called()
+        assert any("no download at all" in str(c) for c in downloader.to_screen.call_args_list)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -9,7 +9,11 @@ _mock_lang = MagicMock()
 _mock_lang.GuiField = MagicMock()
 _mock_lang.get_text = MagicMock(side_effect=lambda field: f"text_{field}")
 
-for mod in ["sys_vars", "i18n", "i18n.lang", "yt_dlp.postprocessor.ffmpeg", "core.hwaccel"]:
+# core.encode no longer reaches into yt_dlp for its progress tracker, so yt_dlp
+# does not have to be mocked here any more. Mocking it also broke every later test
+# module that imports the real yt_dlp, since a mocked yt_dlp.postprocessor.ffmpeg
+# leaves yt_dlp.postprocessor unimportable as a package.
+for mod in ["sys_vars", "i18n", "i18n.lang", "core.hwaccel"]:
     sys.modules[mod] = MagicMock()
 sys.modules["i18n.lang"] = _mock_lang
 
@@ -449,7 +453,7 @@ class TestProgressFfmpeg:
     @patch("core.encode.os.path.getsize", return_value=1000000)
     def test_tracker_called(self, mock_getsize, mock_tracker_cls):
         tracker = MagicMock()
-        tracker.run_ffmpeg_subprocess.return_value = ("", "", 0)
+        tracker.run.return_value = ("", "", 0)
         mock_tracker_cls.return_value = tracker
         cancel = MagicMock()
         cancel.is_cancelled.return_value = False
@@ -462,13 +466,13 @@ class TestProgressFfmpeg:
             120,
         )
         mock_tracker_cls.assert_called_once()
-        tracker.run_ffmpeg_subprocess.assert_called_once()
+        tracker.run.assert_called_once()
 
     @patch("core.encode.FFmpegProgressTracker")
     @patch("core.encode.os.path.getsize", return_value=1000000)
     def test_nonzero_retcode_raises(self, mock_getsize, mock_tracker_cls):
         tracker = MagicMock()
-        tracker.run_ffmpeg_subprocess.return_value = ("", "error output", 1)
+        tracker.run.return_value = ("", "error output", 1)
         mock_tracker_cls.return_value = tracker
         cancel = MagicMock()
         cancel.is_cancelled.return_value = False

--- a/tests/test_ffmpeg_progress.py
+++ b/tests/test_ffmpeg_progress.py
@@ -1,0 +1,192 @@
+import shutil
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from core.ffmpeg_progress import (
+    FFmpegProgressTracker,
+    bitrate_to_bits_per_second,
+    duration_to_process,
+    ffmpeg_time_to_seconds,
+)
+
+# A stand in for ffmpeg: writes the same progress blocks to stdout, some noise to
+# stderr, and exits. Lets the tracker be tested for real, as a subprocess, on a
+# machine with no ffmpeg.
+FAKE_FFMPEG = textwrap.dedent(
+    """
+    import sys
+    blocks, duration = int(sys.argv[1]), float(sys.argv[2])
+    for i in range(1, blocks + 1):
+        out_time = duration * i / blocks
+        sys.stderr.write(f"frame {i} encoded\\n")
+        sys.stdout.write(
+            "frame= 100\\n"
+            "fps= 25\\n"
+            "stream_0_0_q= 28.0\\n"
+            "bitrate= 1500.0kbits/s\\n"
+            "total_size= 999\\n"
+            f"out_time_us= {int(out_time * 1_000_000)}\\n"
+            f"out_time_ms= {int(out_time * 1_000_000)}\\n"
+            f"out_time= {out_time}\\n"
+            "dup_frames= 0\\n"
+            "drop_frames= 0\\n"
+            "speed= 2.0x\\n"
+            f"progress= {'end' if i == blocks else 'continue'}\\n"
+        )
+        sys.stdout.flush()
+    sys.exit(int(sys.argv[3]))
+    """
+)
+
+
+def fake_ffmpeg_args(blocks: int, duration: float, returncode: int = 0) -> list[str]:
+    return [sys.executable, "-c", FAKE_FFMPEG, str(blocks), str(duration), str(returncode)]
+
+
+class TestFfmpegTimeToSeconds:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("42", 42),
+            ("1:30", 90),
+            ("1:00:00", 3600),
+            ("0:0:1.5", 1.5),
+            ("500ms", 0.5),
+            ("250000us", 0.25),
+            ("12s", 12),
+            ("garbage", 0),
+        ],
+    )
+    def test_parses_every_format_ffmpeg_accepts(self, value, expected):
+        assert ffmpeg_time_to_seconds(value) == expected
+
+
+class TestBitrate:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("1500kbits/s", 1_500_000),
+            ("1.5mbits/s", 1_500_000),
+            ("128bits/s", 128),
+            ("2gbits/s", 2_000_000_000),
+            ("N/A", 0),
+        ],
+    )
+    def test_parses_bitrates(self, value, expected):
+        assert bitrate_to_bits_per_second(value) == expected
+
+
+class TestDurationToProcess:
+    def test_whole_file_without_seek_flags(self):
+        assert duration_to_process(["-i", "in.mp4", "out.mp4"], 120) == 120
+
+    def test_trimmed_range(self):
+        assert duration_to_process(["-ss", "60", "-to", "90", "-i", "in.mp4", "out.mp4"], 120) == 30
+
+    def test_explicit_duration_wins(self):
+        assert duration_to_process(["-ss", "10", "-t", "5", "-i", "in.mp4", "out.mp4"], 120) == 5
+
+    def test_from_end(self):
+        assert duration_to_process(["-sseof", "20", "-i", "in.mp4", "out.mp4"], 120) == 20
+
+    def test_inline_value_form(self):
+        assert duration_to_process(["-ss=60", "-to=90", "-i", "in.mp4", "out.mp4"], 120) == 30
+
+    def test_no_duration_means_nothing_to_measure(self):
+        assert duration_to_process(["-i", "in.mp4"], 0) == 0
+
+    def test_negative_range_is_clamped(self):
+        assert duration_to_process(["-ss", "90", "-to", "60", "-i", "in.mp4"], 120) == 0
+
+
+class TestFFmpegProgressTracker:
+    def test_reports_progress_up_to_the_total(self):
+        reports = []
+        tracker = FFmpegProgressTracker(
+            fake_ffmpeg_args(blocks=4, duration=10),
+            reports.append,
+            duration=10,
+            total_bytes=1000,
+            filename="out.mp4",
+        )
+        _, _, returncode = tracker.run()
+
+        assert returncode == 0
+        progressed = [r for r in reports if r["processed_bytes"] > 0]
+        assert progressed, "the tracker never reported any progress"
+        assert [r["processed_bytes"] for r in progressed] == sorted(r["processed_bytes"] for r in progressed)
+        assert progressed[-1]["processed_bytes"] == 1000
+        assert progressed[-1]["total_bytes"] == 1000
+        assert progressed[-1]["status"] == "processing"
+        assert progressed[-1]["filename"] == "out.mp4"
+        assert progressed[-1]["speed"] == 1_500_000
+
+    def test_scales_the_total_to_a_trimmed_range(self):
+        reports = []
+        tracker = FFmpegProgressTracker(
+            [*fake_ffmpeg_args(blocks=2, duration=5), "-ss", "0", "-t", "5"],
+            reports.append,
+            duration=10,
+            total_bytes=1000,
+        )
+        tracker.run()
+
+        # Half the media is being processed, so the output is worth half the bytes.
+        assert reports[-1]["total_bytes"] == 500
+
+    def test_eta_counts_down(self):
+        reports = []
+        tracker = FFmpegProgressTracker(fake_ffmpeg_args(blocks=4, duration=100), reports.append, duration=100)
+        tracker.run()
+
+        etas = [r["eta"] for r in reports if r.get("eta") is not None]
+        assert etas == sorted(etas, reverse=True)
+        assert etas[-1] == 0
+
+    def test_reports_nothing_without_a_duration_but_still_runs(self):
+        reports = []
+        tracker = FFmpegProgressTracker(fake_ffmpeg_args(blocks=2, duration=10), reports.append, duration=0)
+        _, _, returncode = tracker.run()
+
+        assert returncode == 0
+        assert all(r["processed_bytes"] == 0 for r in reports)
+
+    def test_surfaces_the_return_code_and_stderr_of_a_failed_run(self):
+        tracker = FFmpegProgressTracker(
+            fake_ffmpeg_args(blocks=1, duration=10, returncode=1),
+            lambda status: None,
+            duration=10,
+        )
+        _, stderr, returncode = tracker.run()
+
+        assert returncode == 1
+        assert "frame 1 encoded" in stderr
+
+
+@pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not on PATH")
+class TestAgainstRealFfmpeg:
+    def test_tracks_a_real_transcode(self, tmp_path):
+        source = tmp_path / "source.mp4"
+        subprocess.run(
+            ["ffmpeg", "-y", "-f", "lavfi", "-i", "testsrc=duration=3:size=320x240:rate=15", str(source)],
+            check=True,
+            capture_output=True,
+        )
+
+        output = tmp_path / "out.mp4"
+        reports = []
+        tracker = FFmpegProgressTracker(
+            ["ffmpeg", "-y", "-i", str(source), "-c:v", "libx264", "-preset", "ultrafast", str(output)],
+            reports.append,
+            duration=3,
+            total_bytes=source.stat().st_size,
+            filename=str(output),
+        )
+        _, stderr, returncode = tracker.run()
+
+        assert returncode == 0, stderr
+        assert output.is_file()
+        assert any(r["processed_bytes"] > 0 for r in reports), "real ffmpeg produced no progress"

--- a/tests/test_ytdlp_patch.py
+++ b/tests/test_ytdlp_patch.py
@@ -1,0 +1,119 @@
+import inspect
+import shutil
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# tests/test_download.py replaces the whole yt_dlp package tree in sys.modules with
+# MagicMocks and never puts it back, so any module imported after it gets the mock.
+# This file is the one place that must see the real yt-dlp: it exists to check our
+# assumptions against it. Drop the mocks before importing.
+for _name in [
+    name for name, mod in list(sys.modules.items()) if name.startswith("yt_dlp") and isinstance(mod, MagicMock)
+]:
+    del sys.modules[_name]
+
+from yt_dlp import YoutubeDL  # noqa: E402
+from yt_dlp.postprocessor import ffmpeg as ffmpeg_pp  # noqa: E402
+from yt_dlp.postprocessor.common import PostProcessor  # noqa: E402
+from yt_dlp.postprocessor.ffmpeg import FFmpegPostProcessor  # noqa: E402
+
+from core import ytdlp_patch  # noqa: E402
+
+
+class TestSeams:
+    """Guard the yt-dlp internals core/ytdlp_patch.py reaches into.
+
+    These are the load-bearing assumptions. When a yt-dlp bump moves one of them,
+    this fails in CI, which is the whole point: the alternative was discovering it
+    in a release, or maintaining a fork of yt-dlp to avoid the question.
+    """
+
+    def test_real_run_ffmpeg_still_has_the_signature_we_wrap(self):
+        params = inspect.signature(FFmpegPostProcessor.real_run_ffmpeg).parameters
+        assert list(params) == ["self", "input_path_opts", "output_path_opts", "expected_retcodes"]
+        assert params["expected_retcodes"].kind is inspect.Parameter.KEYWORD_ONLY
+
+    def test_real_run_ffmpeg_still_runs_its_command_through_the_module_popen(self):
+        source = inspect.getsource(ffmpeg_pp.FFmpegPostProcessor.real_run_ffmpeg)
+        assert "Popen.run(" in source, "real_run_ffmpeg no longer runs ffmpeg through Popen.run"
+        assert inspect.isclass(ffmpeg_pp.Popen)
+        assert isinstance(inspect.getattr_static(ffmpeg_pp.Popen, "run"), classmethod)
+
+    def test_hook_progress_still_reaches_postprocessor_hooks(self):
+        params = inspect.signature(PostProcessor._hook_progress).parameters
+        assert list(params) == ["self", "status", "info_dict"]
+
+    def test_metadata_object_still_probes_the_duration(self):
+        assert callable(FFmpegPostProcessor.get_metadata_object)
+
+
+class TestInstall:
+    def test_replaces_the_seams_and_is_idempotent(self):
+        ytdlp_patch.install()
+        patched_run = FFmpegPostProcessor.real_run_ffmpeg
+        patched_popen = ffmpeg_pp.Popen
+
+        ytdlp_patch.install()
+
+        assert FFmpegPostProcessor.real_run_ffmpeg is patched_run
+        assert ffmpeg_pp.Popen is patched_popen
+        assert ytdlp_patch._ORIGINAL_POPEN is not None
+        assert issubclass(ffmpeg_pp.Popen, ytdlp_patch._ORIGINAL_POPEN)
+
+    def test_gives_up_quietly_when_a_seam_is_missing(self, monkeypatch, caplog):
+        """A yt-dlp that moved must cost the progress bar, never the download."""
+        monkeypatch.setattr(ytdlp_patch, "_installed", False)
+        monkeypatch.delattr(ffmpeg_pp, "Popen")
+
+        ytdlp_patch.install()
+
+        assert not ytdlp_patch._installed
+        assert "yt-dlp has moved" in caplog.text
+
+
+@pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not on PATH")
+class TestAgainstRealYtDlp:
+    def test_a_real_postprocessor_reports_progress(self, tmp_path):
+        """The end of the fork, proven: yt-dlp's own ffmpeg run drives our bar."""
+        source = tmp_path / "source.mp4"
+        subprocess.run(
+            ["ffmpeg", "-y", "-f", "lavfi", "-i", "testsrc=duration=3:size=320x240:rate=15", str(source)],
+            check=True,
+            capture_output=True,
+        )
+
+        ytdlp_patch.install()
+
+        reports = []
+        with YoutubeDL({"quiet": True}) as ydl:
+            pp = FFmpegPostProcessor(ydl)
+            pp.add_progress_hook(reports.append)
+            pp.run_ffmpeg(str(source), str(tmp_path / "out.mp4"), ["-c:v", "libx264", "-preset", "ultrafast"])
+
+        progressed = [r for r in reports if r.get("processed_bytes", 0) > 0]
+        assert progressed, "yt-dlp ran ffmpeg but reported no progress"
+        assert progressed[-1]["status"] == "processing"
+        assert progressed[-1]["total_bytes"] > 0
+        # yt-dlp stamps the reports itself, which is the proof they went through
+        # its own hook plumbing rather than straight from us to the test.
+        assert progressed[-1]["postprocessor"]
+        assert "info_dict" in progressed[-1]
+
+    def test_ffprobe_calls_are_left_alone(self, tmp_path):
+        """Only the ffmpeg run is intercepted. The probe that measures it must not be."""
+        source = tmp_path / "source.mp4"
+        subprocess.run(
+            ["ffmpeg", "-y", "-f", "lavfi", "-i", "testsrc=duration=1:size=160x120:rate=10", str(source)],
+            check=True,
+            capture_output=True,
+        )
+
+        ytdlp_patch.install()
+
+        with YoutubeDL({"quiet": True}) as ydl:
+            metadata = FFmpegPostProcessor(ydl).get_metadata_object(str(source))
+
+        assert float(metadata["format"]["duration"]) == pytest.approx(1, abs=0.5)

--- a/uv.lock
+++ b/uv.lock
@@ -1101,7 +1101,7 @@ dependencies = [
     { name = "flet" },
     { name = "quantiphy" },
     { name = "tomlkit" },
-    { name = "yt-dlp-enhanced-progress", extra = ["default"] },
+    { name = "yt-dlp", extra = ["default"] },
 ]
 
 [package.optional-dependencies]
@@ -1139,7 +1139,7 @@ requires-dist = [
     { name = "tomlkit" },
     { name = "tufup", marker = "extra == 'desktop'", specifier = ">=0.10" },
     { name = "tufup", marker = "extra == 'dev'", specifier = ">=0.10" },
-    { name = "yt-dlp-enhanced-progress", extras = ["default"], specifier = "==2026.3.13.160948" },
+    { name = "yt-dlp", extras = ["default"], specifier = "==2026.7.4" },
 ]
 provides-extras = ["desktop", "dev"]
 
@@ -1221,26 +1221,17 @@ wheels = [
 ]
 
 [[package]]
-name = "yt-dlp-ejs"
-version = "0.5.0"
+name = "yt-dlp"
+version = "2026.7.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/0d/b9e4ab1b47cdeba0842df634b74b3c0144307640ad5b632a5e189c4ab7ce/yt_dlp_ejs-0.5.0.tar.gz", hash = "sha256:8dfae59e418232f485253dcf8e197fefa232423c3af7824fe19e4517b173293b", size = 98925, upload-time = "2026-02-21T19:29:16.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/5b/1283356b70d4893a8a050cee15092e1b08ea15310b94365f88067146721b/yt_dlp_ejs-0.5.0-py3-none-any.whl", hash = "sha256:674fc0efea741d3100cdf3f0f9e123150715ee41edf47ea7a62fbdeda204bdec", size = 54032, upload-time = "2026-02-21T19:29:15.408Z" },
-]
-
-[[package]]
-name = "yt-dlp-enhanced-progress"
-version = "2026.3.13.160948"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/ef/009acade9d39669d2b4b389fc4c3af012fbad06b5751e4dec27222dfa63f/yt_dlp_enhanced_progress-2026.3.13.160948.tar.gz", hash = "sha256:7cfe5b5847380daa255f2af9a3e1d1e43db10dec6c363c3204704a900869a147", size = 3133011, upload-time = "2026-03-13T16:29:19.747Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/eb/19ef86203e691017f912a2fcd12620431f056f1e3bee3b8fa2c654ba417e/yt_dlp_enhanced_progress-2026.3.13.160948-py3-none-any.whl", hash = "sha256:61bae841837eaa4e4372198eee9228b974b6c24de2acb177ff9c84534bea5bc1", size = 3321447, upload-time = "2026-03-13T16:29:17.802Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
 ]
 
 [package.optional-dependencies]
 default = [
-    { name = "brotli", marker = "implementation_name == 'cpython'" },
+    { name = "brotli", marker = "implementation_name == 'cpython' and sys_platform != 'ios'" },
     { name = "brotlicffi", marker = "implementation_name != 'cpython'" },
     { name = "certifi" },
     { name = "mutagen" },
@@ -1249,4 +1240,13 @@ default = [
     { name = "urllib3" },
     { name = "websockets" },
     { name = "yt-dlp-ejs" },
+]
+
+[[package]]
+name = "yt-dlp-ejs"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/e6/cceb9530e8f4e5940f6f7822d90e9d94f1b85343329a16baaf47bbbb3de1/yt_dlp_ejs-0.8.0.tar.gz", hash = "sha256:d5fa1639f63b5c4af8d932495f60689d5370f1a095782c944f7f62a303eb104e", size = 96571, upload-time = "2026-03-17T22:49:19.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/bd/520769863744b669440a924271a6159ddd82ad5ae26b4ac4d4b69e9f8d44/yt_dlp_ejs-0.8.0-py3-none-any.whl", hash = "sha256:79300e5fca7f937a1eeede11f0456862c1b41107ce1d726871e0207424f4bdb4", size = 53443, upload-time = "2026-03-17T22:49:17.736Z" },
 ]


### PR DESCRIPTION
video-dl no longer forks yt-dlp. It depends on upstream `yt-dlp[default]==2026.7.4` from PyPI, and keeps every progress bar it had.

## Why the fork existed, and why it does not need to

The fork bought exactly two things, and neither needed a fork.

**1. ffmpeg progress for the app's own encoding.** `core/encode.py` imported `FFmpegProgressTracker` from `yt_dlp.postprocessor.ffmpeg` and used it on video-dl's *own* ffmpeg command, with a fake ydl object. It parses an argument list, runs a subprocess and calls back. It is now `core/ffmpeg_progress.py`, with no yt-dlp import at all.

**2. ffmpeg progress for yt-dlp's own postprocessing** (merge, audio extraction, SponsorBlock cuts, trims) **and aria2c download progress.** That part genuinely reaches into yt-dlp, but the coupling was never as deep as the fork made it look. The fork threaded an `information=` kwarg through `run_ffmpeg`, `run_ffmpeg_multiple_files`, `real_run_ffmpeg` and every subclass, and added 150 lines of *console* progress printing that a GUI has no use for. That is 600 lines touching yt-dlp's core, which is why upstream PR #2475 has sat open for four years.

The kwarg only ever existed to carry the media duration. An ffprobe on the input gives it, and yt-dlp already exposes `FFmpegPostProcessor.get_metadata_object` for exactly that. Take the kwarg away and the whole patch collapses into one interception:

| what we need | what upstream already gives us |
|---|---|
| run ffmpeg with `-progress pipe:1` | `FFmpegPostProcessor.real_run_ffmpeg`, the single call that runs a command |
| report to the app | `PostProcessor._hook_progress`, already routed to `postprocessor_hooks` |
| the duration | `FFmpegPostProcessor.get_metadata_object` |

`core/ytdlp_patch.py` wraps that one method. It deliberately does **not** rebuild yt-dlp's ffmpeg command line: upstream still builds it, and only the call that runs it is swapped, so whatever flags upstream adds or fixes, we inherit. `core/aria2c_progress.py` does the same for `Aria2cFD`, on the seams upstream still has (`_call_downloader`, `_call_process`, `_hook_progress`), without reintroducing the m3u8/dash fragment support upstream deleted for GHSA-vx4q-3cr2-7cg2.

This is not a new technique here: `core/download.py:79` already patched `FFmpegFD.available` at runtime.

## aria2c is not a detail

`gui/app.py` sets aria2c as the external downloader for `http`, and yt-dlp shortens `https` to that same key, so aria2c handles most downloads. Dropping the fork without porting its RPC progress would have frozen the download bar for nearly every download. It is ported.

## Failing loudly instead of silently

Both patches reach into yt-dlp internals, so both fail soft at runtime: a moved seam costs the progress bar, never the download. What makes that safe rather than sloppy is that the failure is not allowed to be quiet:

- `tests/test_ytdlp_patch.py` and `tests/test_aria2c_progress.py` assert every seam against the yt-dlp that is actually installed, so a yt-dlp bump that breaks them fails CI.
- `--selftest`, which CI runs against the frozen binary, now refuses to pass unless both patches apply.

## What this ends

No fork, no `yt-dlp-enhanced-progress` on PyPI, no nightly sync cron, no `YT_DLP_DISPATCH_TOKEN`, no merge conflicts against upstream deletions, and no more shipping a yt-dlp that is four months old, which is the thing that actually breaks YouTube.

## Verified

430 tests pass, ruff and mypy clean. Beyond the unit tests, this was exercised against real ffmpeg: a real transcode is tracked end to end, and a real `FFmpegPostProcessor` run drives the progress hooks through yt-dlp's own plumbing. The frozen binary prints `selftest ok (yt-dlp 2026.07.04)`.

A bug came along for the ride: the fork parsed `1:30` as an hour and thirty seconds. It is a minute and a half.