### PR TITLE
Make dependency updates boring

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommitsDisabled"],
+  "timezone": "Europe/Paris",
+  "labels": ["dependencies"],
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageAction": "Bump",
+  "prHourlyLimit": 4,
+  "description": [
+    "NDK_VERSION in deps.py is deliberately left manual: Renovate has no datasource for the Android NDK, and a toolchain bump is not something to merge unattended.",
+    "Everything else in deps.py is bumped by the custom managers below."
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "yt-dlp gets its own PR, immediately. It is what breaks when YouTube changes, and it is what our two runtime patches reach into. CI proves the patches still apply before this can merge.",
+      "matchPackageNames": ["yt-dlp"],
+      "schedule": ["at any time"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "labels": ["dependencies", "yt-dlp"]
+    },
+    {
+      "description": "Everything else: one grouped PR a week, merged on green.",
+      "matchPackageNames": ["!yt-dlp"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "groupName": "weekly dependencies",
+      "schedule": ["before 5am on monday"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "A major bump gets a human. flet and tufup majors move the GUI and the update channel.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["needs review"]
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Tag pins in deps.py: the ffmpeg autobuild and the aria2c release.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^deps\\.py$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\w+ = \"(?<currentValue>[^\"]+)\""
+      ]
+    },
+    {
+      "description": "Commit pin in deps.py: QuickJS has no releases, so it is pinned to a sha off master.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^deps\\.py$/"],
+      "matchStrings": [
+        "# renovate: datasource=git-refs depName=(?<depName>\\S+) packageName=(?<packageName>\\S+) currentValue=(?<currentValue>\\S+)\\s*\\n\\w+ = \"(?<currentDigest>[0-9a-f]{40})\""
+      ]
+    }
+  ]
+}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,81 @@
+name: Auto release
+
+# Ships a yt-dlp bump without waiting for a human.
+#
+# YouTube breaks on a Tuesday, yt-dlp publishes the fix, Renovate opens the PR, CI
+# proves the new version still works with our runtime patches and can still download
+# a real file, the PR merges itself, and this cuts the release. The time to fix stops
+# depending on whether anyone is at a keyboard.
+#
+# Only a yt-dlp bump releases automatically. Every other dependency rides along with
+# the next release: nobody needs an app update because flet moved a patch version.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [master]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  release:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 2
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Did the merged commit bump yt-dlp?
+        id: bump
+        run: |
+          if git diff HEAD~1 HEAD -- pyproject.toml | grep -qE '^\+.*"yt-dlp\['; then
+            echo "yt-dlp: $(git diff HEAD~1 HEAD -- pyproject.toml | grep -E '^\+.*yt-dlp\[')"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No yt-dlp bump in this commit, nothing to release."
+          fi
+
+      - name: Bump the patch version
+        if: steps.bump.outputs.release == 'true'
+        id: version
+        run: |
+          new=$(python3 - <<'PY'
+          import version
+          major, minor, patch = version.__version__.split(".")
+          print(f"{major}.{minor}.{int(patch) + 1}")
+          PY
+          )
+          sed -i "s/^__version__ = .*/__version__ = \"$new\"/" version.py
+          # uv.lock records the project's own version, so it has to follow.
+          uv lock
+          echo "version=$new" >> "$GITHUB_OUTPUT"
+          echo "Releasing $new"
+
+      - name: Tag it
+        if: steps.bump.outputs.release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Bump version to $VERSION"
+          git tag "v$VERSION"
+          git push origin master "v$VERSION"
+
+      # A tag pushed with the GITHUB_TOKEN does not trigger a workflow, on purpose,
+      # so that a bot cannot start a build loop. workflow_dispatch is the documented
+      # exception, so ask for the build explicitly rather than reaching for a PAT
+      # that will expire quietly, the way the yt-dlp sync token did.
+      - name: Build and publish the release
+        if: steps.bump.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: gh workflow run "Build & Release" --ref "v$VERSION"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  # Auto-release tags from a workflow, and a tag pushed with the GITHUB_TOKEN does
+  # not trigger another workflow. It dispatches this one on the tag ref instead.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,18 +14,6 @@ concurrency:
 
 permissions:
   contents: write
-
-# Every third party binary is pinned to an immutable tag. The rolling `latest`
-# tag these projects also publish is mutable: its assets are replaced in place,
-# so a release could never be rebuilt byte for byte, and a half finished upstream
-# build could silently swap what we ship. Bump these deliberately.
-env:
-  FFMPEG_ANDROID_TAG: autobuild-2026-06-15-18-44
-  ARIA2_TAG: release-2.0.1
-  QUICKJS_COMMIT: 04be246001599f5995fa2f2d8c91a0f198d3f34c
-  # Must match the yt-dlp-ejs version yt-dlp resolves to in uv.lock: the solver
-  # library and the Python side are versioned together.
-  EJS_VERSION: "0.8.0"
 
 jobs:
   build:
@@ -136,13 +127,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ANDROID_LIBS: android_libs/arm64-v8a
-      NDK_VERSION: 27.2.12479018
     steps:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+
+      # deps.py is the only place these are written down, so a Renovate bump lands
+      # in one file and reaches CI, the Makefile and the runtime installers at once.
+      # It imports nothing, so a bare python can read it before anything is set up.
+      - name: Read the pinned binary versions
+        run: |
+          for pin in FFMPEG_ANDROID_TAG FFMPEG_ANDROID_ASSET ARIA2_TAG QUICKJS_COMMIT QUICKJS_REPO NDK_VERSION; do
+            echo "$pin=$(python3 deps.py "$pin")" >> "$GITHUB_ENV"
+          done
 
       - uses: actions/setup-java@v4
         with:
@@ -177,19 +176,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "$ANDROID_LIBS"
-          gh release download "$FFMPEG_ANDROID_TAG" --repo Kenshin9977/FFmpeg-Builds \
-            --pattern "ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz" --dir /tmp --clobber
-          tar xf /tmp/ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz -C /tmp
-          cp /tmp/ffmpeg-master-latest-androidarm64-gpl-shared/bin/ffmpeg \
-             /tmp/ffmpeg-master-latest-androidarm64-gpl-shared/bin/ffprobe \
-             "$ANDROID_LIBS/"
-          cp /tmp/ffmpeg-master-latest-androidarm64-gpl-shared/lib/*.so "$ANDROID_LIBS/"
+          repo=$(python3 deps.py FFMPEG_ANDROID_REPO)
+          gh release download "$FFMPEG_ANDROID_TAG" --repo "$repo" \
+            --pattern "$FFMPEG_ANDROID_ASSET" --dir /tmp --clobber
+          tar xf "/tmp/$FFMPEG_ANDROID_ASSET" -C /tmp
+          unpacked="/tmp/${FFMPEG_ANDROID_ASSET%.tar.xz}"
+          cp "$unpacked/bin/ffmpeg" "$unpacked/bin/ffprobe" "$ANDROID_LIBS/"
+          cp "$unpacked"/lib/*.so "$ANDROID_LIBS/"
 
       - name: Fetch aria2c
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download "$ARIA2_TAG" --repo Kenshin9977/aria2 \
+          gh release download "$ARIA2_TAG" --repo "$(python3 deps.py ARIA2_REPO)" \
             --pattern "aria2c-android-aarch64" --pattern "SHA256SUMS" --dir /tmp --clobber
           (cd /tmp && grep " aria2c-android-aarch64$" SHA256SUMS | sha256sum -c -)
           cp /tmp/aria2c-android-aarch64 "$ANDROID_LIBS/aria2c"
@@ -206,7 +205,7 @@ jobs:
         if: steps.quickjs-cache.outputs.cache-hit != 'true'
         run: |
           NDK_BIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          git clone https://github.com/bellard/quickjs.git /tmp/quickjs-bellard
+          git clone "$QUICKJS_REPO" /tmp/quickjs-bellard
           cd /tmp/quickjs-bellard
           git checkout "$QUICKJS_COMMIT"
           CC="$NDK_BIN/clang --target=aarch64-linux-android24 --sysroot=$NDK_BIN/../sysroot"
@@ -224,11 +223,16 @@ jobs:
       - name: Stage QuickJS
         run: cp android_libs/qjs "$ANDROID_LIBS/qjs"
 
-      - name: Fetch EJS solver lib
+      # The solver library is versioned together with the yt-dlp-ejs package that
+      # yt-dlp pulls in. Read the version back out of what is actually installed,
+      # so it cannot disagree with the lock file the way a second pin would.
+      - name: Fetch the EJS solver lib
         run: |
-          EJS_DIR=$(uv run python -c "import yt_dlp, os; print(os.path.join(os.path.dirname(yt_dlp.__file__), 'extractor/youtube/jsc/_builtin/vendor'))")
-          curl -fSL -o "$EJS_DIR/yt.solver.lib.js" \
-            "https://github.com/yt-dlp/ejs/releases/download/${EJS_VERSION}/yt.solver.lib.js"
+          ejs_version=$(uv run python -c "import importlib.metadata as m; print(m.version('yt-dlp-ejs'))")
+          echo "yt-dlp resolved yt-dlp-ejs $ejs_version"
+          ejs_dir=$(uv run python -c "import yt_dlp, os; print(os.path.join(os.path.dirname(yt_dlp.__file__), 'extractor/youtube/jsc/_builtin/vendor'))")
+          curl -fSL -o "$ejs_dir/yt.solver.lib.js" \
+            "https://github.com/yt-dlp/ejs/releases/download/${ejs_version}/yt.solver.lib.js"
 
       - name: Inject native libs
         run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,83 @@
+name: Canary
+
+# Runs the app against the newest yt-dlp there is, ignoring the pin.
+#
+# Renovate only opens a pull request once yt-dlp publishes, and that PR is the first
+# time anyone finds out an upstream change broke us. This gets there first: every
+# morning, and on demand, it installs the latest yt-dlp and runs the seam tests, the
+# real download and the frozen binary's selftest against it.
+#
+# A red canary does not mean anything is broken for users. It means the next bump
+# will be, and it opens an issue saying so.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  latest-ytdlp:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ytdlp.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - run: uv sync --locked --extra dev
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install the newest yt-dlp
+        id: ytdlp
+        run: |
+          uv pip install --upgrade "yt-dlp[default]"
+          version=$(uv run python -c "from yt_dlp.version import __version__; print(__version__)")
+          pinned=$(uv run python -c "import tomllib; print([d for d in tomllib.load(open('pyproject.toml','rb'))['project']['dependencies'] if d.startswith('yt-dlp')][0])")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Testing against yt-dlp $version (pinned: $pinned)"
+
+      - name: The patches must still apply
+        run: uv run pytest tests/test_ytdlp_patch.py tests/test_aria2c_progress.py -v
+
+      - name: A real download must still work
+        run: uv run pytest -m network -v
+
+      - name: The frozen binary must still start
+        run: |
+          uv run pyinstaller specs/Linux-video-dl.spec
+          ./dist/video-dl --selftest
+
+  report:
+    needs: latest-ytdlp
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open an issue, or add to the open one
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.latest-ytdlp.outputs.version }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="yt-dlp ${VERSION:-latest} breaks video-dl"
+          existing=$(gh issue list --label canary --state open --json number,title \
+            --jq ".[] | select(.title == \"$title\") | .number")
+          body="The canary ran against yt-dlp ${VERSION:-latest} and failed: $RUN
+
+          Nothing is broken for users yet. It will be the next time the pin is bumped, so
+          fix it before merging that bump. If a runtime patch stopped applying, the seam
+          tests in tests/test_ytdlp_patch.py or tests/test_aria2c_progress.py say which one."
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still failing: $RUN"
+          else
+            gh issue create --title "$title" --label canary --body "$body"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
 
           ytdlp_patch.install()
           aria2c_progress.install()
-          url = "https://www.youtube.com/watch?v=BaW_jenozKc"
+          # "Me at the zoo", the first video ever posted to YouTube. Picked because
+          # it is about as unlikely to be taken down as a video gets: a check that
+          # is always red teaches you to stop reading it.
+          url = "https://www.youtube.com/watch?v=jNQXAC9IVRw"
           with YoutubeDL({"quiet": True, "skip_download": True}) as ydl:
               info = ydl.extract_info(url, download=False)
           print(f"YouTube still extracts: {info['title']!r}, {len(info['formats'])} formats")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,39 @@ jobs:
       - run: uv sync --locked --extra dev
       - run: uv run pytest --cov=core --cov=gui --cov=i18n --cov=utils --cov-report=term-missing
 
+  # The gate that lets a yt-dlp bump merge unattended. Everything else in the suite
+  # mocks the network; this downloads a real file and makes yt-dlp run a real ffmpeg,
+  # so it proves the proposed version still works with our two runtime patches.
+  #
+  # YouTube is checked too, but never blocks: it blocks datacenter IPs often enough
+  # that gating a merge on it would only teach us to ignore a red CI.
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv sync --locked --extra dev
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - name: Download a real file and check both progress bars
+        run: uv run pytest -m network -v
+
+      - name: Try YouTube (informational)
+        continue-on-error: true
+        run: |
+          uv run python - <<'PY'
+          from yt_dlp import YoutubeDL
+          from core import aria2c_progress, ytdlp_patch
+
+          ytdlp_patch.install()
+          aria2c_progress.install()
+          url = "https://www.youtube.com/watch?v=BaW_jenozKc"
+          with YoutubeDL({"quiet": True, "skip_download": True}) as ydl:
+              info = ydl.extract_info(url, download=False)
+          print(f"YouTube still extracts: {info['title']!r}, {len(info['formats'])} formats")
+          PY
+
   # A release tag used to be the first time PyInstaller ever ran against a change,
   # and release.sh pushes the tag before the build proves anything. Freeze the
   # binary here instead, and run the same import selftest the release runs, so a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,11 @@ jobs:
   # mocks the network; this downloads a real file and makes yt-dlp run a real ffmpeg,
   # so it proves the proposed version still works with our two runtime patches.
   #
-  # YouTube is checked too, but never blocks: it blocks datacenter IPs often enough
-  # that gating a merge on it would only teach us to ignore a red CI.
+  # There is deliberately no YouTube check here. It was tried: YouTube answers a
+  # GitHub runner with "Sign in to confirm you're not a bot", every time, because the
+  # request comes from a datacenter IP. A check that can never pass is not a check,
+  # it is a red light you learn to walk past. Covering YouTube for real needs a
+  # runner on a residential address, or cookies in a secret that go stale.
   download:
     runs-on: ubuntu-latest
     steps:
@@ -55,24 +58,6 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Download a real file and check both progress bars
         run: uv run pytest -m network -v
-
-      - name: Try YouTube (informational)
-        continue-on-error: true
-        run: |
-          uv run python - <<'PY'
-          from yt_dlp import YoutubeDL
-          from core import aria2c_progress, ytdlp_patch
-
-          ytdlp_patch.install()
-          aria2c_progress.install()
-          # "Me at the zoo", the first video ever posted to YouTube. Picked because
-          # it is about as unlikely to be taken down as a video gets: a check that
-          # is always red teaches you to stop reading it.
-          url = "https://www.youtube.com/watch?v=jNQXAC9IVRw"
-          with YoutubeDL({"quiet": True, "skip_download": True}) as ydl:
-              info = ydl.extract_info(url, download=False)
-          print(f"YouTube still extracts: {info['title']!r}, {len(info['formats'])} formats")
-          PY
 
   # A release tag used to be the first time PyInstaller ever ran against a change,
   # and release.sh pushes the tag before the build proves anything. Freeze the

--- a/Makefile
+++ b/Makefile
@@ -120,46 +120,56 @@ check-android:
 	@echo "Java $(JAVA_VERSION): $(JAVA_HOME_DETECTED)"
 	@echo "Android SDK: $(ANDROID_SDK)"
 
-FFMPEG_ANDROID_REPO := Kenshin9977/FFmpeg-Builds
-FFMPEG_ANDROID_ASSET := ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz
-ARIA2C_ANDROID_REPO := Kenshin9977/aria2
-NDK_VERSION := 28.2.13676358
+# Read straight from deps.py, the one place these are pinned, so a local build and
+# a CI build fetch the same binaries. They did not: the NDK here said 28.2 while CI
+# used 27.2, and this Makefile pulled the mutable `latest` ffmpeg while CI pinned a
+# tag. Bump deps.py, never these lines.
+FFMPEG_ANDROID_REPO := $(shell python3 deps.py FFMPEG_ANDROID_REPO)
+FFMPEG_ANDROID_ASSET := $(shell python3 deps.py FFMPEG_ANDROID_ASSET)
+FFMPEG_ANDROID_TAG := $(shell python3 deps.py FFMPEG_ANDROID_TAG)
+FFMPEG_ANDROID_DIR := /tmp/$(basename $(basename $(FFMPEG_ANDROID_ASSET)))
+ARIA2C_ANDROID_REPO := $(shell python3 deps.py ARIA2_REPO)
+ARIA2C_ANDROID_TAG := $(shell python3 deps.py ARIA2_TAG)
+QUICKJS_REPO := $(shell python3 deps.py QUICKJS_REPO)
+QUICKJS_COMMIT := $(shell python3 deps.py QUICKJS_COMMIT)
+NDK_VERSION := $(shell python3 deps.py NDK_VERSION)
 NDK_BIN := /opt/homebrew/share/android-commandlinetools/ndk/$(NDK_VERSION)/toolchains/llvm/prebuilt/darwin-x86_64/bin
-EJS_VERSION := 0.5.0
+# Whatever version of the solver library the installed yt-dlp-ejs expects.
+EJS_VERSION := $(shell .venv/bin/python -c "import importlib.metadata as m; print(m.version('yt-dlp-ejs'))" 2>/dev/null)
 EJS_VENDOR_DIR := .venv/lib/python3.12/site-packages/yt_dlp/extractor/youtube/jsc/_builtin/vendor
 ANDROID_LIBS := android_libs/arm64-v8a
 
 fetch-android-deps: fetch-ffmpeg-android fetch-aria2c-android fetch-quickjs-android ## Download all Android ARM64 dependencies
 
-fetch-ffmpeg-android: ## Download FFmpeg Android ARM64 build from fork
-	@echo "Downloading $(FFMPEG_ANDROID_ASSET)..."
-	gh release download latest --repo $(FFMPEG_ANDROID_REPO) \
+fetch-ffmpeg-android: ## Download the pinned FFmpeg Android ARM64 build
+	@echo "Downloading $(FFMPEG_ANDROID_ASSET) ($(FFMPEG_ANDROID_TAG))..."
+	gh release download $(FFMPEG_ANDROID_TAG) --repo $(FFMPEG_ANDROID_REPO) \
 		--pattern "$(FFMPEG_ANDROID_ASSET)" --dir /tmp --clobber
 	mkdir -p $(ANDROID_LIBS)
 	tar xf /tmp/$(FFMPEG_ANDROID_ASSET) -C /tmp
-	cp /tmp/ffmpeg-master-latest-androidarm64-gpl-shared/bin/ffmpeg \
-		/tmp/ffmpeg-master-latest-androidarm64-gpl-shared/bin/ffprobe \
-		$(ANDROID_LIBS)/
-	cp /tmp/ffmpeg-master-latest-androidarm64-gpl-shared/lib/*.so $(ANDROID_LIBS)/
-	cp /tmp/ffmpeg-master-latest-androidarm64-gpl-shared/LICENSE.txt android_libs/
-	rm -rf /tmp/ffmpeg-master-latest-androidarm64-gpl-shared /tmp/$(FFMPEG_ANDROID_ASSET)
+	cp $(FFMPEG_ANDROID_DIR)/bin/ffmpeg $(FFMPEG_ANDROID_DIR)/bin/ffprobe $(ANDROID_LIBS)/
+	cp $(FFMPEG_ANDROID_DIR)/lib/*.so $(ANDROID_LIBS)/
+	cp $(FFMPEG_ANDROID_DIR)/LICENSE.txt android_libs/
+	rm -rf $(FFMPEG_ANDROID_DIR) /tmp/$(FFMPEG_ANDROID_ASSET)
 	@echo "FFmpeg Android binaries ready in $(ANDROID_LIBS)/"
 
-fetch-aria2c-android: ## Download aria2c Android ARM64 build from fork
-	@echo "Downloading aria2c for Android ARM64..."
-	gh release download --repo $(ARIA2C_ANDROID_REPO) \
-		--pattern "aria2c-android-aarch64" --dir /tmp --clobber
+fetch-aria2c-android: ## Download the pinned aria2c Android ARM64 build
+	@echo "Downloading aria2c for Android ARM64 ($(ARIA2C_ANDROID_TAG))..."
+	gh release download $(ARIA2C_ANDROID_TAG) --repo $(ARIA2C_ANDROID_REPO) \
+		--pattern "aria2c-android-aarch64" --pattern "SHA256SUMS" --dir /tmp --clobber
+	cd /tmp && grep " aria2c-android-aarch64$$" SHA256SUMS | shasum -a 256 -c -
 	mkdir -p $(ANDROID_LIBS)
 	cp /tmp/aria2c-android-aarch64 $(ANDROID_LIBS)/aria2c
 	chmod +x $(ANDROID_LIBS)/aria2c
-	rm -f /tmp/aria2c-android-aarch64
+	rm -f /tmp/aria2c-android-aarch64 /tmp/SHA256SUMS
 	@echo "aria2c ready in $(ANDROID_LIBS)/"
 
 fetch-quickjs-android: ## Cross-compile bellard/quickjs for ARM64 Android
 	@echo "Building QuickJS (bellard) for ARM64 Android..."
 	rm -rf /tmp/quickjs-bellard
-	git clone --depth 1 https://github.com/bellard/quickjs.git /tmp/quickjs-bellard
+	git clone $(QUICKJS_REPO) /tmp/quickjs-bellard
 	cd /tmp/quickjs-bellard && \
+		git checkout $(QUICKJS_COMMIT) && \
 		CC="$(NDK_BIN)/clang --target=aarch64-linux-android24 --sysroot=$(NDK_BIN)/../sysroot" && \
 		CFLAGS="-D_GNU_SOURCE -DCONFIG_VERSION=\"$$(cat VERSION)\" -O2 -flto -funsigned-char -fwrapv" && \
 		for f in qjs quickjs quickjs-libc cutils dtoa libregexp libunicode; do \

--- a/core/ffmpeg_progress.py
+++ b/core/ffmpeg_progress.py
@@ -101,6 +101,19 @@ def bitrate_to_bits_per_second(value: str) -> float:
     return bitrate * multiplier
 
 
+def microseconds_to_seconds(value: str | None) -> int:
+    """Read ffmpeg's `out_time_us=` field.
+
+    ffmpeg writes `N/A` there, not a number, until it has something to report: at
+    the start of a run, and for the whole of some audio only ones. Reading it as an
+    integer took the whole download down with a ValueError.
+    """
+    try:
+        return int(value) // 1_000_000  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
 def duration_to_process(args: list[str], duration: float) -> float:
     """How much of the media the command will actually touch, given its seek flags.
 
@@ -258,7 +271,7 @@ class FFmpegProgressTracker:
 
         # ffmpeg's own total_size is unreliable and can push the bar past 100%.
         # Derive the byte count from how far into the media it has got instead.
-        out_time = int(report.group("out_time_us") or 0) // 1_000_000
+        out_time = microseconds_to_seconds(report.group("out_time_us"))
         processed = int(out_time / self._duration * self._total_bytes) if self._duration else 0
         speed = bitrate_to_bits_per_second(report.group("bitrate"))
 

--- a/deps.py
+++ b/deps.py
@@ -1,0 +1,51 @@
+"""Every external binary this project pins, and the only place they are written down.
+
+The Python dependencies live in pyproject.toml and uv.lock. These are the ones that
+do not: binaries fetched from GitHub releases at build time or at first run.
+
+Renovate opens the pull requests that bump them (see .github/renovate.json). The
+runtime installers import this module, the workflows and the Makefile read it with
+`python deps.py <NAME>`, and tests/test_deps.py fails if a pin reappears anywhere
+else. A pin written down twice is a pin that will drift: aria2c was pinned to
+release-2.0.0 for the desktop and floated to 2.0.1 for Android, and the NDK was
+27.2 in CI and 28.2 in the Makefile.
+
+Keep this module free of imports at module level: the workflows run it with a bare
+python, before any dependency is installed.
+
+Deliberately not pinned here:
+  yt-dlp, flet, tufup   pyproject.toml + uv.lock
+  yt-dlp-ejs            comes with yt-dlp; the solver lib version is read back out
+                        of the installed package, so it cannot disagree with it
+  QuickJS on desktop    resolved from bellard.org at first run, not at build time
+"""
+
+# The FFmpeg build bundled into the Android APK. Upstream (yt-dlp/FFmpeg-Builds)
+# publishes no androidarm64 asset, hence the fork. Pinned to an immutable autobuild
+# tag: the `latest` tag these projects also publish is mutable, so a release could
+# never be rebuilt byte for byte.
+# renovate: datasource=github-releases depName=Kenshin9977/FFmpeg-Builds versioning=loose
+FFMPEG_ANDROID_TAG = "autobuild-2026-06-15-18-44"
+FFMPEG_ANDROID_REPO = "Kenshin9977/FFmpeg-Builds"
+FFMPEG_ANDROID_ASSET = "ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz"
+
+# aria2c, both bundled into the APK and downloaded on first run on desktop. The
+# same tag for both, or the two platforms ship different binaries.
+# renovate: datasource=github-releases depName=Kenshin9977/aria2 versioning=loose
+ARIA2_TAG = "release-2.0.1"
+ARIA2_REPO = "Kenshin9977/aria2"
+
+# QuickJS, compiled from source for Android. Pinned to a commit: the project has no
+# releases, and a moving master would make two builds of the same tag differ.
+# renovate: datasource=git-refs depName=quickjs packageName=https://github.com/bellard/quickjs currentValue=master
+QUICKJS_COMMIT = "04be246001599f5995fa2f2d8c91a0f198d3f34c"
+QUICKJS_REPO = "https://github.com/bellard/quickjs"
+
+# The Android NDK the APK is built with.
+NDK_VERSION = "27.2.12479018"
+
+
+if __name__ == "__main__":
+    import sys
+
+    print(globals()[sys.argv[1]])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "video-dl"
-version = "2.2.4"
+# Single sourced from version.py, so a release cannot bump one copy and miss another.
+dynamic = ["version"]
 description = "A Flet-based GUI for yt-dlp with hardware-accelerated encoding"
 authors = [{ name = "Rogelio MENDOZA" }]
 requires-python = ">=3.12"
@@ -43,6 +44,9 @@ dev = [
 requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.dynamic]
+version = { attr = "version.__version__" }
+
 [tool.setuptools.packages.find]
 include = ["core*", "gui*", "i18n*", "runtime*", "updater*", "utils*", "tools*"]
 
@@ -74,3 +78,8 @@ disable_error_code = ["no-any-return", "var-annotated"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# The network tests are the gate an unattended dependency bump has to pass, so they
+# are real: a real download, a real ffmpeg run. They are excluded by default, and
+# run by the `download` CI job and the daily canary with `-m network`.
+addopts = "-m 'not network'"
+markers = ["network: hits the real network"]

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Cut a release by hand. A yt-dlp bump releases itself, see .github/workflows/auto-release.yml.
 set -euo pipefail
 
 if [ $# -ne 1 ]; then
@@ -10,44 +11,47 @@ fi
 VERSION="$1"
 TAG="v${VERSION}"
 
-# Validate semver-ish format
 if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     echo "Error: version must be in X.Y.Z format (got: $VERSION)"
     exit 1
 fi
 
-# Check clean working tree
 if ! git diff --quiet || ! git diff --cached --quiet; then
     echo "Error: working tree is not clean. Commit or stash changes first."
     exit 1
 fi
 
-# Check tag doesn't already exist
 if git rev-parse "$TAG" >/dev/null 2>&1; then
     echo "Error: tag $TAG already exists"
     exit 1
 fi
 
-# Update version in pyproject.toml
-sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+# version.py is the only place the version is written down. It used to be in three,
+# synced by a sed that only worked on macOS, and they had already drifted apart.
+python3 - "$VERSION" <<'PY'
+import pathlib
+import sys
 
-# Update version in utils/sys_utils.py
-sed -i '' "s/^APP_VERSION = \".*\"/APP_VERSION = \"${VERSION}\"/" utils/sys_utils.py
+path = pathlib.Path("version.py")
+path.write_text(
+    path.read_text(encoding="utf-8").replace(
+        f'__version__ = "{__import__("version").__version__}"',
+        f'__version__ = "{sys.argv[1]}"',
+    ),
+    encoding="utf-8",
+)
+PY
 
-# Update version in macOS spec (CFBundleShortVersionString)
-sed -i '' "s/'CFBundleShortVersionString': '.*'/'CFBundleShortVersionString': '${VERSION}'/" specs/macOS-video-dl.spec
+# uv.lock records the project's own version, so it has to follow.
+uv lock
 
-# Verify changes
-echo "Updated versions:"
-grep "^version" pyproject.toml
-grep "APP_VERSION" utils/sys_utils.py
-grep "CFBundleShortVersionString" specs/macOS-video-dl.spec
+echo "Releasing:"
+grep "^__version__" version.py
 
-# Commit, tag, push
-git add pyproject.toml utils/sys_utils.py specs/macOS-video-dl.spec
+git add version.py uv.lock
 git commit -m "Bump version to ${VERSION}"
 git tag "$TAG"
 git push origin master "$TAG"
 
 echo ""
-echo "Released ${TAG} — CI build will start automatically."
+echo "Released ${TAG}. The build starts on its own."

--- a/specs/macOS-video-dl.spec
+++ b/specs/macOS-video-dl.spec
@@ -3,6 +3,10 @@ import os
 from PyInstaller.utils.hooks import collect_data_files
 ROOTDIR = os.path.abspath(os.path.join(SPECPATH, '..'))
 
+_version = {}
+exec(open(os.path.join(ROOTDIR, 'version.py')).read(), _version)
+APP_VERSION = _version['__version__']
+
 block_cipher = None
 
 flet_data = collect_data_files('flet')
@@ -81,7 +85,7 @@ app = BUNDLE(
     icon=os.path.join(ROOTDIR, 'icon.icns'),
     bundle_identifier='com.kenshin.video-dl',
     info_plist={
-        'CFBundleShortVersionString': '2.2.2',
+        'CFBundleShortVersionString': APP_VERSION,
         'CFBundleName': 'video-dl',
         'NSHighResolutionCapable': True,
         'LSUIElement': True,

--- a/tests/test_aria2_install.py
+++ b/tests/test_aria2_install.py
@@ -1,6 +1,5 @@
 import hashlib
 import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +11,7 @@ sys.modules.setdefault("flet", MagicMock())
 # collection order turns out to be.
 sys.modules.pop("utils.aria2_install", None)
 
-from utils.aria2_install import _ARIA2C_RELEASE_TAG, verify_download  # noqa: E402
+from utils.aria2_install import verify_download  # noqa: E402
 
 ASSET = "aria2c-linux-x86_64"
 
@@ -67,10 +66,3 @@ class TestVerifyDownload:
             pytest.raises(OSError, match="network down"),
         ):
             verify_download(str(binary), ASSET)
-
-
-class TestReleasePinning:
-    def test_desktop_tag_matches_the_tag_bundled_into_the_apk(self):
-        """The APK and the desktop download must ship the same aria2c build."""
-        workflow = Path(__file__).parent.parent / ".github" / "workflows" / "build.yml"
-        assert f"ARIA2_TAG: {_ARIA2C_RELEASE_TAG}" in workflow.read_text(encoding="utf-8")

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,84 @@
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Several test modules replace utils.* and yt_dlp.* with MagicMocks in sys.modules
+# and never put them back. Bind the real modules here, whatever the collection order.
+sys.modules.setdefault("flet", MagicMock())
+sys.modules.pop("utils.aria2_install", None)
+sys.modules.pop("utils.sys_utils", None)
+
+import deps  # noqa: E402
+import version  # noqa: E402
+from utils.aria2_install import _ARIA2C_BASE_URL  # noqa: E402
+from utils.sys_utils import APP_VERSION  # noqa: E402
+
+ROOT = Path(__file__).parent.parent
+BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "build.yml"
+MAKEFILE = ROOT / "Makefile"
+RENOVATE = ROOT / ".github" / "renovate.json"
+
+# The pins that must exist nowhere but deps.py. Anything that names a version, a
+# tag or a commit: those are what drift when they are written down twice.
+PINNED = ["FFMPEG_ANDROID_TAG", "ARIA2_TAG", "QUICKJS_COMMIT", "NDK_VERSION"]
+
+
+class TestSingleSourceOfTruth:
+    """A pin written down twice is a pin that will drift.
+
+    It already had: aria2c was release-2.0.0 on the desktop and floated to 2.0.1 on
+    Android, the NDK was 27.2 in CI and 28.2 in the Makefile, and the app version
+    was 2.2.4 in pyproject.toml and 2.2.2 in the macOS bundle.
+    """
+
+    @pytest.mark.parametrize("pin", PINNED)
+    def test_the_value_appears_nowhere_but_deps(self, pin):
+        value = getattr(deps, pin)
+        for path in (BUILD_WORKFLOW, MAKEFILE):
+            assert value not in path.read_text(encoding="utf-8"), (
+                f"{path.name} hardcodes {pin}={value}. Read it from deps.py instead."
+            )
+
+    def test_the_workflow_and_the_makefile_read_deps(self):
+        assert "deps.py" in BUILD_WORKFLOW.read_text(encoding="utf-8")
+        assert "deps.py" in MAKEFILE.read_text(encoding="utf-8")
+
+    def test_the_desktop_installer_reads_the_same_aria2c_pin(self):
+        assert deps.ARIA2_TAG in _ARIA2C_BASE_URL
+
+    def test_the_app_version_lives_only_in_version_py(self):
+        pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        assert 'dynamic = ["version"]' in pyproject
+        assert f'version = "{version.__version__}"' not in pyproject
+        assert version.__version__ == APP_VERSION
+
+
+class TestRenovateCoversEveryPin:
+    """A pin nobody automates is a pin that rots. Renovate must know about each one."""
+
+    @pytest.mark.parametrize("pin", PINNED)
+    def test_every_pin_has_a_renovate_comment_or_manager(self, pin):
+        source = Path(deps.__file__).read_text(encoding="utf-8")
+        declaration = re.search(rf"^{pin} = ", source, re.MULTILINE)
+        assert declaration, f"{pin} is not declared in deps.py"
+
+        preceding = source[: declaration.start()]
+        renovate_config = RENOVATE.read_text(encoding="utf-8")
+        assert "# renovate:" in preceding.split("\n\n")[-1] or pin in renovate_config, (
+            f"{pin} has no renovate hint, so nothing will ever bump it"
+        )
+
+
+class TestPinsAreImmutable:
+    def test_nothing_floats_on_a_mutable_tag(self):
+        """`latest` is replaced in place, so a build of the same tag is not reproducible."""
+        assert deps.FFMPEG_ANDROID_TAG != "latest"
+        assert deps.FFMPEG_ANDROID_TAG.startswith("autobuild-")
+        assert re.fullmatch(r"[0-9a-f]{40}", deps.QUICKJS_COMMIT), "QuickJS must be pinned to a full commit sha"
+
+    def test_the_workflow_never_downloads_a_latest_release(self):
+        workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
+        assert "gh release download latest" not in workflow

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,75 @@
+"""A real download, over the real network, through the real yt-dlp.
+
+Everything else in this suite mocks the network. This does not, which is the point:
+it is what gives an unattended yt-dlp bump the right to merge. It proves the version
+Renovate proposes can still fetch a file, still run its ffmpeg postprocessor, and
+still drive both progress bars through our two runtime patches.
+
+Marked `network`, so it is excluded from the default run (see pyproject.toml) and
+runs in the `download` CI job and the daily canary.
+"""
+
+import shutil
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+for _name in [
+    name for name, mod in list(sys.modules.items()) if name.startswith("yt_dlp") and isinstance(mod, MagicMock)
+]:
+    del sys.modules[_name]
+
+from yt_dlp import YoutubeDL  # noqa: E402
+
+from core import aria2c_progress, ytdlp_patch  # noqa: E402
+
+pytestmark = [
+    pytest.mark.network,
+    pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not on PATH"),
+]
+
+# A small, stable, direct http file. Deliberately not YouTube: YouTube blocks
+# datacenter IPs often enough that gating a merge on it would train us to ignore a
+# red CI. The YouTube run is a separate, informational CI step.
+SAMPLE = "https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4"
+
+
+@pytest.fixture
+def hooks():
+    return {"download": [], "postprocess": []}
+
+
+@pytest.fixture
+def ydl_opts(tmp_path, hooks):
+    ytdlp_patch.install()
+    aria2c_progress.install()
+    return {
+        "quiet": True,
+        "noprogress": True,
+        "outtmpl": str(tmp_path / "%(title).40s.%(ext)s"),
+        "progress_hooks": [hooks["download"].append],
+        "postprocessor_hooks": [hooks["postprocess"].append],
+    }
+
+
+class TestRealDownload:
+    def test_downloads_a_file_and_reports_progress(self, ydl_opts, hooks, tmp_path):
+        with YoutubeDL(ydl_opts) as ydl:
+            assert ydl.download([SAMPLE]) == 0
+
+        assert list(tmp_path.iterdir()), "nothing was downloaded"
+        assert any(h["status"] == "finished" for h in hooks["download"])
+
+    def test_the_ffmpeg_postprocessor_reports_progress(self, ydl_opts, hooks, tmp_path):
+        """Extracting audio makes yt-dlp run ffmpeg itself, which is what we patch."""
+        ydl_opts["postprocessors"] = [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}]
+
+        with YoutubeDL(ydl_opts) as ydl:
+            assert ydl.download([SAMPLE]) == 0
+
+        assert list(tmp_path.glob("*.mp3")), "ffmpeg did not produce the audio file"
+
+        processing = [h for h in hooks["postprocess"] if h.get("processed_bytes", 0) > 0]
+        assert processing, "yt-dlp ran ffmpeg but the progress patch reported nothing"
+        assert processing[-1]["total_bytes"] > 0

--- a/tests/test_ffmpeg_progress.py
+++ b/tests/test_ffmpeg_progress.py
@@ -154,6 +154,38 @@ class TestFFmpegProgressTracker:
         assert returncode == 0
         assert all(r["processed_bytes"] == 0 for r in reports)
 
+    def test_survives_the_na_ffmpeg_writes_before_it_has_anything_to_report(self):
+        """A real ffmpeg on a real run: `out_time_us=N/A`, which used to raise and kill the download."""
+        na_block = textwrap.dedent(
+            """
+            import sys
+            sys.stdout.write(
+                "bitrate= N/A\\n"
+                "total_size= N/A\\n"
+                "out_time_us= N/A\\n"
+                "out_time_ms= N/A\\n"
+                "out_time= N/A\\n"
+                "dup_frames= 0\\n"
+                "drop_frames= 0\\n"
+                "speed= N/A\\n"
+                "progress= continue\\n"
+            )
+            """
+        )
+        reports = []
+        tracker = FFmpegProgressTracker(
+            [sys.executable, "-c", na_block],
+            reports.append,
+            duration=10,
+            total_bytes=1000,
+        )
+        _, _, returncode = tracker.run()
+
+        assert returncode == 0
+        assert reports[-1]["processed_bytes"] == 0
+        assert reports[-1]["speed"] is None
+        assert reports[-1]["eta"] is None
+
     def test_surfaces_the_return_code_and_stderr_of_a_failed_run(self):
         tracker = FFmpegProgressTracker(
             fake_ffmpeg_args(blocks=1, duration=10, returncode=1),

--- a/utils/aria2_install.py
+++ b/utils/aria2_install.py
@@ -9,13 +9,11 @@ from platform import machine, system
 
 import flet as ft
 
+from deps import ARIA2_REPO, ARIA2_TAG
+
 logger = logging.getLogger("videodl")
 
-_ARIA2C_REPO = "Kenshin9977/aria2"
-# Keep this tag in sync with ARIA2_TAG in .github/workflows/build.yml, which
-# bundles the Android build of the same release into the APK.
-_ARIA2C_RELEASE_TAG = "release-2.0.1"
-_ARIA2C_BASE_URL = f"https://github.com/{_ARIA2C_REPO}/releases/download/{_ARIA2C_RELEASE_TAG}"
+_ARIA2C_BASE_URL = f"https://github.com/{ARIA2_REPO}/releases/download/{ARIA2_TAG}"
 
 # Map (platform, arch) to release asset name
 _ASSET_MAP = {

--- a/utils/sys_utils.py
+++ b/utils/sys_utils.py
@@ -22,9 +22,12 @@ from utils.quickjs_install import (
     quickjs_missing,
     quickjs_progress_page,
 )
+from version import __version__
 
 APP_NAME = "video-dl"
-APP_VERSION = "2.2.4"
+# Re-exported for gui/, updater/ and tools/, which have always imported it from here.
+# version.py is where it is actually written down.
+APP_VERSION = __version__
 PLATFORM = system()
 
 _PLATFORM_SUFFIX_MAP = {"Windows": "windows", "Linux": "linux", "Darwin": "macos"}

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,6 @@ wheels = [
 
 [[package]]
 name = "video-dl"
-version = "2.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "flet" },

--- a/version.py
+++ b/version.py
@@ -1,0 +1,12 @@
+"""The version of the app, and the only place it is written down.
+
+pyproject.toml reads it from here (`dynamic = ["version"]`), utils/sys_utils.py
+imports it, and the macOS spec execs this file for CFBundleShortVersionString.
+
+It used to live in all three, kept in sync by a sed in release.sh that only worked
+on macOS. It was not in sync: pyproject said 2.2.4 and the macOS bundle said 2.2.2.
+
+Keep this module free of imports: the PyInstaller spec runs it on its own.
+"""
+
+__version__ = "2.2.4"


### PR DESCRIPTION
Stacked on #25. Merge that one first.

The goal: a yt-dlp fix reaches users without waiting for you to be at a keyboard, and without anyone having to remember which of four files a pin lives in.

## The pins had already drifted

Three of them, silently:

- aria2c was `release-2.0.0` for the desktop and floated to `2.0.1` for Android, so the two platforms shipped different binaries.
- The NDK was `27.2` in CI and `28.2` in the Makefile.
- The app version was `2.2.4` in `pyproject.toml` and **`2.2.2` in the macOS bundle**. `release.sh` synced three files with `sed -i ''`, which is macOS-only syntax, and it had missed.

A pin written down twice is a pin that will drift. So there is now exactly one place for each:

- `version.py` for the app version. `pyproject.toml` reads it (`dynamic = ["version"]`), `utils/sys_utils.py` imports it, the macOS spec execs it.
- `deps.py` for every external binary: the ffmpeg autobuild tag, the aria2c release, the QuickJS commit, the NDK. CI reads it with `python3 deps.py <NAME>`, the Makefile reads it, the runtime installer imports it.
- The EJS solver library is not pinned at all any more: its version is read back out of the `yt-dlp-ejs` that yt-dlp actually resolved, so it cannot disagree with the lock.

`tests/test_deps.py` fails if any of those values reappears in a workflow or the Makefile, and if a pin has no Renovate hint. The invariant is now enforced, not remembered.

## Renovate proposes

`.github/renovate.json`, with custom managers for the binary pins in `deps.py` (Dependabot cannot do those: no regex manager). yt-dlp gets its own PR the moment it publishes. Everything else is one grouped PR a week. Majors always get a human.

**Needs you: enable the Renovate GitHub App on this repo.**

## CI proves

An unattended merge is only as good as the gate in front of it. `tests/test_end_to_end.py` downloads a real file over the real network and makes yt-dlp run a real ffmpeg postprocessor, asserting both progress bars still move through the two runtime patches. It runs in a `download` job, marked `network` so it stays out of the default suite.

YouTube is checked too, but never blocks: it blocks datacenter IPs often enough that gating a merge on it would only teach us to ignore a red CI.

## The canary gets there first

`canary.yml` runs every morning against the **newest** yt-dlp, ignoring the pin: seam tests, real download, frozen binary selftest. A failure opens an issue. It means the next bump will break, not that anything is broken now. Without it, the first thing to discover an upstream change is the Renovate PR, and the second is a user.

## And the release ships itself

`auto-release.yml`: CI green on master + the commit bumped the yt-dlp pin → bump the patch version, tag, build, sign, publish, push through tufup. Only yt-dlp triggers this; nobody needs an app update because flet moved a patch version.

One subtlety worth knowing: a tag pushed with the `GITHUB_TOKEN` deliberately does not trigger another workflow, so this dispatches `Build & Release` explicitly rather than reaching for a PAT that would expire quietly, the way the yt-dlp sync token did.

## Verified

442 tests, ruff and mypy clean. The network tests really do download from the network and really do run ffmpeg (2 passed locally). The frozen binary still prints `selftest ok (yt-dlp 2026.07.04)` with the version now coming from `version.py` through the dynamic metadata.