### PR TITLE
Make the download bar move when ffmpeg is the downloader

### DIFF
--- a/core/ffmpeg_progress.py
+++ b/core/ffmpeg_progress.py
@@ -101,6 +101,14 @@ def bitrate_to_bits_per_second(value: str) -> float:
     return bitrate * multiplier
 
 
+def to_int(value: str | None) -> int:
+    """ffmpeg writes `N/A` rather than a number whenever it has nothing to report yet."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
 def microseconds_to_seconds(value: str | None) -> int:
     """Read ffmpeg's `out_time_us=` field.
 
@@ -170,9 +178,11 @@ class FFmpegProgressReporter:
         filename: str = "",
         bytes_key: str = "processed_bytes",
         status: str = "processing",
+        bytes_from_output: bool = False,
     ) -> None:
         self._on_progress = on_progress
         self._bytes_key = bytes_key
+        self._bytes_from_output = bytes_from_output
         self._block = ""
         self._started_at = time.time()
 
@@ -189,8 +199,8 @@ class FFmpegProgressReporter:
 
     @property
     def reports_anything(self) -> bool:
-        """False when ffmpeg's output cannot be turned into a ratio, so why bother reading it."""
-        return bool(self._duration)
+        """False when there is nothing we could report, so why even ask ffmpeg for it."""
+        return bool(self._duration or self._bytes_from_output)
 
     def feed(self, text: str) -> None:
         """Hand it more of ffmpeg's progress output."""
@@ -208,14 +218,23 @@ class FFmpegProgressReporter:
         self._on_progress(self._status.copy())
 
     def _emit(self, report: re.Match) -> None:
-        # ffmpeg's own total_size is unreliable and can push the bar past 100%.
-        # Derive the byte count from how far into the media it has got instead.
         out_time = microseconds_to_seconds(report.group("out_time_us"))
-        done = int(out_time / self._duration * self._total_bytes) if self._duration else 0
+
+        if self._bytes_from_output:
+            # ffmpeg is downloading, so the bytes it has written are the bytes that
+            # came down the wire. That is a real count, and it needs no duration:
+            # a direct file often has none, and the bar would sit at zero.
+            done = to_int(report.group("total_size"))
+        else:
+            # ffmpeg is encoding, and then total_size is the size of a file that is
+            # still being written: it can overshoot and push the bar past 100%. How
+            # far into the media it has got is the honest measure.
+            done = int(out_time / self._duration * self._total_bytes) if self._duration else 0
 
         self._status.update(
             {
                 self._bytes_key: done,
+                "total_bytes": self._total_bytes or None,
                 "speed": bitrate_to_bits_per_second(report.group("bitrate")) or None,
                 "eta": self._eta(report.group("speed"), out_time),
                 "elapsed": time.time() - self._started_at,

--- a/core/ffmpegfd_progress.py
+++ b/core/ffmpegfd_progress.py
@@ -133,6 +133,8 @@ def _prepare(context: _Context | None, args) -> tuple[FFmpegProgressReporter | N
         filename=context.filename,
         bytes_key="downloaded_bytes",
         status="downloading",
+        # ffmpeg is the downloader here: the bytes it writes are the bytes it fetched.
+        bytes_from_output=True,
     )
     if not reporter.reports_anything:
         # No duration means no ratio to report, so do not even ask ffmpeg for it.

--- a/tests/test_ffmpeg_progress.py
+++ b/tests/test_ffmpeg_progress.py
@@ -146,6 +146,30 @@ class TestFFmpegProgressTracker:
         assert etas == sorted(etas, reverse=True)
         assert etas[-1] == 0
 
+    def test_counts_the_bytes_ffmpeg_wrote_when_it_is_the_one_downloading(self):
+        """Downloading needs no duration: ffmpeg counts the bytes it writes."""
+        from core.ffmpeg_progress import FFmpegProgressReporter
+
+        reports = []
+        reporter = FFmpegProgressReporter(
+            reports.append,
+            args=["ffmpeg"],
+            duration=0,
+            bytes_key="downloaded_bytes",
+            status="downloading",
+            bytes_from_output=True,
+        )
+        assert reporter.reports_anything
+
+        reporter.feed(
+            "bitrate= 100.0kbits/s\ntotal_size=54321\nout_time_us=N/A\nout_time_ms=N/A\nout_time=N/A\n"
+            "dup_frames=0\ndrop_frames=0\nspeed=N/A\nprogress=continue\n"
+        )
+
+        assert reports[-1]["downloaded_bytes"] == 54321
+        assert reports[-1]["status"] == "downloading"
+        assert reports[-1]["total_bytes"] is None
+
     def test_reports_nothing_without_a_duration_but_still_runs(self):
         reports = []
         tracker = FFmpegProgressTracker(fake_ffmpeg_args(blocks=2, duration=10), reports.append, duration=0)

--- a/tests/test_ffmpegfd_progress.py
+++ b/tests/test_ffmpegfd_progress.py
@@ -64,13 +64,18 @@ class TestInstall:
         assert not ffmpegfd_progress._installed
         assert "yt-dlp has moved" in caplog.text
 
-    def test_asks_ffmpeg_for_nothing_when_the_duration_is_unknown(self):
-        """No duration means no ratio to report, so do not even add the flag."""
+    def test_still_reports_when_the_duration_is_unknown(self):
+        """A direct file often has no duration, and the bar used to sit at zero for it.
+
+        It does not need one: ffmpeg is the downloader here, so the bytes it writes
+        are the bytes that came down the wire, and it counts those itself.
+        """
         context = ffmpegfd_progress._Context(MagicMock(), {"filesize": 1000})
         reporter, path = ffmpegfd_progress._prepare(context, ["ffmpeg", "-i", "in.mp4"])
 
-        assert reporter is None
-        assert path is None
+        assert context.duration == 0
+        assert reporter is not None
+        assert path is not None
 
     def test_leaves_every_other_external_downloader_alone(self):
         """The stand-in only touches an ffmpeg run. aria2c, wget and curl go through it too."""


### PR DESCRIPTION
Found by driving the app for real, not by a test: trim a video (start or end timecode) and the download bar sat at zero for the whole download.

Trimming makes yt-dlp hand the download to ffmpeg (`FFmpegFD`), which #27 taught to report progress. But it reported by *time*: how far into the media ffmpeg had got, applied to the file size. A direct http file often has no duration in its info dict, so there was no ratio, so the reporter stayed quiet and the bar never moved.

It never needed a duration. When ffmpeg is the one downloading, the bytes it writes are the bytes that came down the wire, and it counts them itself in `total_size`. So the download bar now uses that count, and the encode bar keeps using the time ratio, which is still the right measure there: during an encode `total_size` is the size of a file still being written, and it can overshoot and push the bar past 100%.

Verified against the running app, on a real download:

    TRIM 5s-20s : 608068 bytes on disk
    download bar: 262192 -> 608068 -> finished