### PR TITLE
Fix the Android ffmpeg fetch before it fails a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
       # It imports nothing, so a bare python can read it before anything is set up.
       - name: Read the pinned binary versions
         run: |
-          for pin in FFMPEG_ANDROID_TAG FFMPEG_ANDROID_ASSET ARIA2_TAG QUICKJS_COMMIT QUICKJS_REPO NDK_VERSION; do
+          for pin in FFMPEG_ANDROID_TAG FFMPEG_ANDROID_ASSET_PATTERN ARIA2_TAG QUICKJS_COMMIT QUICKJS_REPO NDK_VERSION; do
             echo "$pin=$(python3 deps.py "$pin")" >> "$GITHUB_ENV"
           done
 
@@ -176,11 +176,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "$ANDROID_LIBS"
-          repo=$(python3 deps.py FFMPEG_ANDROID_REPO)
-          gh release download "$FFMPEG_ANDROID_TAG" --repo "$repo" \
-            --pattern "$FFMPEG_ANDROID_ASSET" --dir /tmp --clobber
-          tar xf "/tmp/$FFMPEG_ANDROID_ASSET" -C /tmp
-          unpacked="/tmp/${FFMPEG_ANDROID_ASSET%.tar.xz}"
+          rm -rf /tmp/ffmpeg-android && mkdir -p /tmp/ffmpeg-android
+          gh release download "$FFMPEG_ANDROID_TAG" --repo "$(python3 deps.py FFMPEG_ANDROID_REPO)" \
+            --pattern "$FFMPEG_ANDROID_ASSET_PATTERN" --dir /tmp/ffmpeg-android
+          # The asset carries the build number, and the directory inside it carries
+          # the same. Read both back rather than guessing either.
+          archive=$(find /tmp/ffmpeg-android -name '*.tar.xz')
+          tar xf "$archive" -C /tmp/ffmpeg-android
+          unpacked=$(find /tmp/ffmpeg-android -mindepth 1 -maxdepth 1 -type d)
           cp "$unpacked/bin/ffmpeg" "$unpacked/bin/ffprobe" "$ANDROID_LIBS/"
           cp "$unpacked"/lib/*.so "$ANDROID_LIBS/"
 

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,8 @@ check-android:
 # used 27.2, and this Makefile pulled the mutable `latest` ffmpeg while CI pinned a
 # tag. Bump deps.py, never these lines.
 FFMPEG_ANDROID_REPO := $(shell python3 deps.py FFMPEG_ANDROID_REPO)
-FFMPEG_ANDROID_ASSET := $(shell python3 deps.py FFMPEG_ANDROID_ASSET)
+FFMPEG_ANDROID_ASSET_PATTERN := $(shell python3 deps.py FFMPEG_ANDROID_ASSET_PATTERN)
 FFMPEG_ANDROID_TAG := $(shell python3 deps.py FFMPEG_ANDROID_TAG)
-FFMPEG_ANDROID_DIR := /tmp/$(basename $(basename $(FFMPEG_ANDROID_ASSET)))
 ARIA2C_ANDROID_REPO := $(shell python3 deps.py ARIA2_REPO)
 ARIA2C_ANDROID_TAG := $(shell python3 deps.py ARIA2_TAG)
 QUICKJS_REPO := $(shell python3 deps.py QUICKJS_REPO)
@@ -142,15 +141,15 @@ ANDROID_LIBS := android_libs/arm64-v8a
 fetch-android-deps: fetch-ffmpeg-android fetch-aria2c-android fetch-quickjs-android ## Download all Android ARM64 dependencies
 
 fetch-ffmpeg-android: ## Download the pinned FFmpeg Android ARM64 build
-	@echo "Downloading $(FFMPEG_ANDROID_ASSET) ($(FFMPEG_ANDROID_TAG))..."
+	@echo "Downloading FFmpeg for Android ARM64 ($(FFMPEG_ANDROID_TAG))..."
+	rm -rf /tmp/ffmpeg-android && mkdir -p /tmp/ffmpeg-android $(ANDROID_LIBS)
 	gh release download $(FFMPEG_ANDROID_TAG) --repo $(FFMPEG_ANDROID_REPO) \
-		--pattern "$(FFMPEG_ANDROID_ASSET)" --dir /tmp --clobber
-	mkdir -p $(ANDROID_LIBS)
-	tar xf /tmp/$(FFMPEG_ANDROID_ASSET) -C /tmp
-	cp $(FFMPEG_ANDROID_DIR)/bin/ffmpeg $(FFMPEG_ANDROID_DIR)/bin/ffprobe $(ANDROID_LIBS)/
-	cp $(FFMPEG_ANDROID_DIR)/lib/*.so $(ANDROID_LIBS)/
-	cp $(FFMPEG_ANDROID_DIR)/LICENSE.txt android_libs/
-	rm -rf $(FFMPEG_ANDROID_DIR) /tmp/$(FFMPEG_ANDROID_ASSET)
+		--pattern "$(FFMPEG_ANDROID_ASSET_PATTERN)" --dir /tmp/ffmpeg-android
+	tar xf /tmp/ffmpeg-android/*.tar.xz -C /tmp/ffmpeg-android
+	cp /tmp/ffmpeg-android/ffmpeg-*/bin/ffmpeg /tmp/ffmpeg-android/ffmpeg-*/bin/ffprobe $(ANDROID_LIBS)/
+	cp /tmp/ffmpeg-android/ffmpeg-*/lib/*.so $(ANDROID_LIBS)/
+	cp /tmp/ffmpeg-android/ffmpeg-*/LICENSE.txt android_libs/
+	rm -rf /tmp/ffmpeg-android
 	@echo "FFmpeg Android binaries ready in $(ANDROID_LIBS)/"
 
 fetch-aria2c-android: ## Download the pinned aria2c Android ARM64 build

--- a/deps.py
+++ b/deps.py
@@ -27,7 +27,13 @@ Deliberately not pinned here:
 # renovate: datasource=github-releases depName=Kenshin9977/FFmpeg-Builds versioning=loose
 FFMPEG_ANDROID_TAG = "autobuild-2026-06-15-18-44"
 FFMPEG_ANDROID_REPO = "Kenshin9977/FFmpeg-Builds"
-FFMPEG_ANDROID_ASSET = "ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz"
+# A pattern, not a name, and that is the whole point: the rolling `latest` release
+# calls this asset ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz, while every
+# dated autobuild release stamps the build and commit into it
+# (ffmpeg-N-125053-gfd290e2fcd-androidarm64-gpl-shared.tar.xz). Pinning the tag and
+# hardcoding the name fetches nothing, and hardcoding the versioned name would break
+# on the next bump. Match on the part that never moves.
+FFMPEG_ANDROID_ASSET_PATTERN = "*androidarm64-gpl-shared.tar.xz"
 
 # aria2c, both bundled into the APK and downloaded on first run on desktop. The
 # same tag for both, or the two platforms ship different binaries.

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -82,3 +82,16 @@ class TestPinsAreImmutable:
     def test_the_workflow_never_downloads_a_latest_release(self):
         workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
         assert "gh release download latest" not in workflow
+
+    def test_the_ffmpeg_asset_is_matched_by_pattern_not_by_name(self):
+        """The name carries the build number, so pinning the tag and naming the file fetches nothing.
+
+        The rolling `latest` release calls it ffmpeg-master-latest-androidarm64-*, and
+        every dated autobuild calls it ffmpeg-N-<build>-g<commit>-androidarm64-*. Naming
+        it would break the build the first time Renovate bumped the tag, which is the
+        one moment nobody is watching.
+        """
+        pattern = deps.FFMPEG_ANDROID_ASSET_PATTERN
+        assert pattern.startswith("*"), "the build number lives at the front, so the wildcard has to"
+        assert "latest" not in pattern, "that name only exists on the rolling release, not on a pinned tag"
+        assert not re.search(r"N-\d+", pattern), "a build number here breaks the next tag bump"


### PR DESCRIPTION
The Android job of the release build would have failed, and the only reason it did not is that nobody has cut a release since the pins landed.

Found by dry-running the fetch steps against the real repositories rather than reading them.

`deps.py` pins the ffmpeg build to an immutable autobuild tag, which is right. But the asset name it asked for, `ffmpeg-master-latest-androidarm64-gpl-shared.tar.xz`, only exists on the *rolling* `latest` release. Every dated autobuild release stamps the build and the commit into the name instead:

    ffmpeg-N-125053-gfd290e2fcd-androidarm64-gpl-shared.tar.xz

So `gh release download` matched nothing and the job died. Hardcoding the versioned name would have been worse: it would break again the first time Renovate bumps the tag, which is exactly the moment nobody is watching.

The pin is now a pattern (`*androidarm64-gpl-shared.tar.xz`), matched against the part of the name that never moves, and the unpacked directory is read back from the archive instead of being guessed from the filename. `tests/test_deps.py` fails if anyone puts a build number or a `latest` back into it.

Verified by running the real fetch, exactly as CI will:

    archive : ffmpeg-N-125053-gfd290e2fcd-androidarm64-gpl-shared.tar.xz
    contents: ffmpeg, ffprobe, 8 shared libraries
    aria2c-android-aarch64: OK   (checksum)