### PR TITLE
Fix the Renovate config it refuses to run with

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,7 +56,8 @@
       "managerFilePatterns": ["/^deps\\.py$/"],
       "matchStrings": [
         "# renovate: datasource=git-refs depName=(?<depName>\\S+) packageName=(?<packageName>\\S+) currentValue=(?<currentValue>\\S+)\\s*\\n\\w+ = \"(?<currentDigest>[0-9a-f]{40})\""
-      ]
+      ],
+      "datasourceTemplate": "git-refs"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,20 @@ jobs:
       - run: uv run ruff format --check .
       - run: uv run mypy .
 
+  # A broken renovate.json does not fail loudly: Renovate opens an issue and then
+  # stops opening pull requests, so dependency updates just quietly stop happening.
+  # That already cost us once (a custom manager with no datasource). Its own
+  # validator catches it, so run it here, where it fails a pull request instead.
+  #
+  # tests/test_deps.py goes further and checks the regexes still match the pins,
+  # which the validator does not: a manager that matches nothing is not an error to
+  # Renovate, it is a pin that silently never gets bumped.
+  renovate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx --yes --package renovate -- renovate-config-validator --strict
+
   # The shipped binary is Windows first, and the Windows specific paths (winreg,
   # the ffmpeg install under LOCALAPPDATA) used to never run in CI on any OS.
   test:

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,3 +1,4 @@
+import json
 import re
 import sys
 from pathlib import Path
@@ -70,6 +71,46 @@ class TestRenovateCoversEveryPin:
         assert "# renovate:" in preceding.split("\n\n")[-1] or pin in renovate_config, (
             f"{pin} has no renovate hint, so nothing will ever bump it"
         )
+
+    def test_the_custom_managers_actually_match_the_pins(self):
+        """Renovate's own validator only checks the schema, not that a regex matches anything.
+
+        A custom manager whose regex matches nothing is not an error: it is a pin that
+        silently never gets bumped, which is the failure we are trying to design out.
+        So run the real matchStrings from renovate.json against the real deps.py.
+        """
+        config = json.loads(RENOVATE.read_text(encoding="utf-8"))
+        source = Path(deps.__file__).read_text(encoding="utf-8")
+
+        found = {}
+        for manager in config["customManagers"]:
+            for match_string in manager["matchStrings"]:
+                # Renovate's regexes are JavaScript, Python spells its groups (?P<x>).
+                pattern = match_string.replace("(?<", "(?P<")
+                for match in re.finditer(pattern, source):
+                    groups = match.groupdict()
+                    found[groups["depName"]] = groups | {
+                        "datasource": groups.get("datasource") or manager.get("datasourceTemplate")
+                    }
+
+        assert set(found) == {"Kenshin9977/FFmpeg-Builds", "Kenshin9977/aria2", "quickjs"}, (
+            f"a custom manager stopped matching: Renovate now sees only {sorted(found)}"
+        )
+        assert found["Kenshin9977/FFmpeg-Builds"]["currentValue"] == deps.FFMPEG_ANDROID_TAG
+        assert found["Kenshin9977/aria2"]["currentValue"] == deps.ARIA2_TAG
+        assert found["quickjs"]["currentDigest"] == deps.QUICKJS_COMMIT
+        assert found["quickjs"]["datasource"] == "git-refs"
+
+    def test_every_custom_manager_names_its_datasource(self):
+        """Renovate refuses the whole config otherwise, and stops opening PRs entirely."""
+        config = json.loads(RENOVATE.read_text(encoding="utf-8"))
+
+        for manager in config["customManagers"]:
+            captures_it = all("(?<datasource>" in m for m in manager["matchStrings"])
+            assert captures_it or manager.get("datasourceTemplate"), (
+                f"custom manager {manager.get('description')!r} names no datasource, "
+                "so Renovate rejects the config and stops every dependency PR"
+            )
 
 
 class TestPinsAreImmutable:


### PR DESCRIPTION
Renovate opened issue #30 and stopped opening pull requests:

    Regex Managers must contain datasourceTemplate configuration or regex group named datasource

The QuickJS custom manager wrote `datasource=git-refs` inside the regex *text* but never captured it as a group, so Renovate had nowhere to read it from. It now declares `"datasourceTemplate": "git-refs"`.

That is a one-line fix. The interesting part is that it stopped every dependency update, and the only way anyone found out was an issue nobody was watching for. So it is now checked twice, in CI:

- **`renovate-config` job**: runs Renovate's own validator (`renovate-config-validator --strict`). It reproduces the exact error above, so this class of mistake now fails a pull request instead of quietly halting the update chain.
- **`tests/test_deps.py`**: runs the real `matchStrings` from `renovate.json` against the real `deps.py`, and asserts all three pins are still captured with the right groups. The validator cannot do this: a custom manager whose regex matches *nothing* is not an error to Renovate, it is a pin that silently never gets bumped, which is exactly the failure this whole setup exists to design out.

Verified: the validator rejects the old config and accepts the new one, and 463 tests pass.