### PR TITLE
Renovate was reading both binary pins and then dropping them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,32 @@ jobs:
       - uses: actions/checkout@v7
       - run: npx --yes --package renovate -- renovate-config-validator --strict
 
+      # The validator only checks the schema. It says nothing about whether Renovate
+      # can actually *do* anything with what it extracted, and that is where this bit
+      # us: it read both binary pins, decided `autobuild-2026-06-15-18-44` and
+      # `release-2.0.1` were "unversioned" under `versioning=loose`, and skipped them.
+      # No error, no PR, ever. The pins were on rails to nowhere.
+      #
+      # So run Renovate itself against this checkout and fail if it skips one of them.
+      - name: Renovate must not silently skip a pin
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_TOKEN: ${{ github.token }}
+          GITHUB_COM_TOKEN: ${{ github.token }}
+        run: |
+          npx --yes --package renovate -- renovate --platform=local --dry-run=lookup > renovate.log 2>&1 || true
+
+          # Deliberately not every dependency: the Windows signing action is pinned to
+          # a moving tag on purpose, and Renovate skipping that one is the right call.
+          skipped=$(grep -E "DEBUG: Skipping (Kenshin9977/FFmpeg-Builds|Kenshin9977/aria2|quickjs)" renovate.log || true)
+          if [ -n "$skipped" ]; then
+            echo "::error::Renovate read a deps.py pin and then dropped it. It will never be bumped."
+            echo "$skipped"
+            grep -E "unsupported/unversioned" renovate.log || true
+            exit 1
+          fi
+          echo "Renovate tracks every pin in deps.py."
+
   # The shipped binary is Windows first, and the Windows specific paths (winreg,
   # the ffmpeg install under LOCALAPPDATA) used to never run in CI on any OS.
   test:

--- a/deps.py
+++ b/deps.py
@@ -24,7 +24,10 @@ Deliberately not pinned here:
 # publishes no androidarm64 asset, hence the fork. Pinned to an immutable autobuild
 # tag: the `latest` tag these projects also publish is mutable, so a release could
 # never be rebuilt byte for byte.
-# renovate: datasource=github-releases depName=Kenshin9977/FFmpeg-Builds versioning=loose
+# The tag is a timestamp, not a version, and `loose` cannot read it: Renovate
+# extracted the pin, called it unversioned, and skipped it without a word. Spell
+# the grammar out so it can compare two autobuilds and know which is newer.
+# renovate: datasource=github-releases depName=Kenshin9977/FFmpeg-Builds versioning=regex:^autobuild-(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)-(?<build>\d+-\d+)$
 FFMPEG_ANDROID_TAG = "autobuild-2026-06-15-18-44"
 FFMPEG_ANDROID_REPO = "Kenshin9977/FFmpeg-Builds"
 # A pattern, not a name, and that is the whole point: the rolling `latest` release
@@ -37,7 +40,8 @@ FFMPEG_ANDROID_ASSET_PATTERN = "*androidarm64-gpl-shared.tar.xz"
 
 # aria2c, both bundled into the APK and downloaded on first run on desktop. The
 # same tag for both, or the two platforms ship different binaries.
-# renovate: datasource=github-releases depName=Kenshin9977/aria2 versioning=loose
+# Same again: `release-2.0.1` is a version wearing a prefix, and `loose` skipped it.
+# renovate: datasource=github-releases depName=Kenshin9977/aria2 versioning=regex:^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 ARIA2_TAG = "release-2.0.1"
 ARIA2_REPO = "Kenshin9977/aria2"
 


### PR DESCRIPTION
The Dependency Dashboard (#37) listed one of the two regex managers with **no dependencies under it**. Running Renovate's own engine against the repo said why:

    DEBUG: Dependency Kenshin9977/FFmpeg-Builds has unsupported/unversioned value
           autobuild-2026-06-15-18-44 (versioning=loose)
    DEBUG: Skipping Kenshin9977/FFmpeg-Builds because no currentDigest or pinDigests

    DEBUG: Dependency Kenshin9977/aria2 has unsupported/unversioned value
           release-2.0.1 (versioning=loose)
    DEBUG: Skipping Kenshin9977/aria2 because no currentDigest or pinDigests

Both binary pins were extracted, declared unversioned, and dropped. No error, no issue, no PR, ever. ffmpeg and aria2c were pinned to rails that went nowhere, and the only trace was a `DEBUG` line nobody reads.

`loose` cannot read a timestamp wearing a prefix (`autobuild-2026-06-15-18-44`) or a version wearing one (`release-2.0.1`). Each pin now spells its grammar out with `versioning=regex:...`, so Renovate can compare two of them and tell which is newer. QuickJS was never affected: it is tracked by digest.

## The part that matters

This is the third time today a link in this chain failed *silently*, and the config validator cannot see it: a manager that extracts a dependency and then skips it is not a schema error.

So CI now runs Renovate itself (`--platform=local --dry-run=lookup`) against the checkout and fails if it drops any pin from `deps.py`. Verified both ways: green on this branch, and it flags exactly 2 dropped pins when run against the old config.

The Windows signing action is deliberately not covered by that check: it is pinned to a moving tag on purpose, and Renovate skipping it is the right call.