### PR TITLE
Do not upgrade Flet, and make sure nothing upgrades it for us

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -525,7 +525,7 @@ class VideodlApp:
             expanded=False,
             maintain_state=True,
             on_change=self._advanced_toggle,
-            controls_padding=ft.padding.only(top=10, left=10, right=10),
+            controls_padding=ft.Padding.only(top=10, left=10, right=10),
             controls=self._build_advanced_controls(timecode_rows),
         )
         logger.debug(
@@ -615,7 +615,7 @@ class VideodlApp:
         if self._mobile and self._encode_label:
             self._encode_row = ft.Container(
                 content=Row(controls=[self.encode_indicator, self._encode_label]),
-                padding=ft.padding.only(bottom=6),
+                padding=ft.Padding.only(bottom=6),
                 visible=False,
             )
             rows.append(self._encode_row)
@@ -1400,7 +1400,7 @@ class VideodlApp:
             on_change=on_change,
         )
         sheet = ft.BottomSheet(
-            content=ft.Container(content=picker, height=216, padding=ft.padding.only(top=6)),
+            content=ft.Container(content=picker, height=216, padding=ft.Padding.only(top=6)),
             dismissible=True,
             on_dismiss=on_dismiss,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,19 @@ description = "A Flet-based GUI for yt-dlp with hardware-accelerated encoding"
 authors = [{ name = "Rogelio MENDOZA" }]
 requires-python = ">=3.12"
 dependencies = [
-    "flet>=0.81",
+    # Pinned exactly, and deliberately NOT taken to 0.83 or later.
+    #
+    # 0.83 took the Flutter runtime out of the flet-desktop package and put it on
+    # GitHub Releases. The frozen binary then drops from 76 MB to 36 MB, and on first
+    # launch it downloads 95 MB from GitHub with urlretrieve, with no checksum, into
+    # ~/.flet, and runs it. An Authenticode-signed exe would be fetching and executing
+    # an unsigned binary, and a user with no network would have no app at all.
+    #
+    # Nothing in 0.82 to 0.85 is used here: Router, use_dialog, Auth0, Maps,
+    # AudioRecorder, ads, CodeEditor. The code migration is three lines (ft.padding.only
+    # is gone, ft.Padding replaces it), verified by running the app on 0.85.3, so the
+    # code is not what holds this back. Revisit when the runtime can be bundled again.
+    "flet==0.81.0",
     "quantiphy",
     "tomlkit",
     # Upstream yt-dlp, not a fork. ffmpeg progress reporting, the one thing the
@@ -25,12 +37,12 @@ dependencies = [
 [project.optional-dependencies]
 desktop = [
     "darkdetect",
-    "flet-desktop>=0.81",
+    "flet-desktop==0.81.0",
     "tufup>=0.10",
 ]
 dev = [
     "darkdetect",
-    "flet-desktop>=0.81",
+    "flet-desktop==0.81.0",
     "mypy",
     "Pillow",
     "pyinstaller",
@@ -78,6 +90,14 @@ disable_error_code = ["no-any-return", "var-annotated"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Flet announces a removal a few versions ahead, and it was right: it said
+# `padding.only()` would go in 0.83, nobody read the warning, and 0.85 broke the app
+# on startup while every test stayed green. A Flet deprecation is now a red test,
+# months before the version that enforces it.
+filterwarnings = [
+    "error::DeprecationWarning:flet.*",
+    "error:.*deprecated since version.*:DeprecationWarning",
+]
 # The network tests are the gate an unattended dependency bump has to pass, so they
 # are real: a real download, a real ffmpeg run. They are excluded by default, and
 # run by the `download` CI job and the daily canary with `-m network`.

--- a/tests/test_gui_builds.py
+++ b/tests/test_gui_builds.py
@@ -1,0 +1,77 @@
+"""Build the real window, with the real Flet, and no display.
+
+Every other test in this suite replaces flet with a MagicMock, which means a Flet
+release can rename half its API and the suite stays green. That is not theoretical:
+flet 0.85 removed `ft.padding.only`, the app died at startup on a red error screen,
+and 463 tests passed anyway. So did `--selftest`, because importing flet still works.
+Only opening the window showed it.
+
+This constructs the whole control tree against the installed Flet, with a stand-in
+for Page. It needs no display and takes milliseconds, and it fails on exactly that
+kind of break.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Other test modules put MagicMocks in sys.modules in place of flet. Dropping those is
+# not enough: gui.app may already have been imported while flet was a mock, and its
+# module level `import flet as ft` stays bound to it. Drop gui.* too, so it is imported
+# again, against the real Flet.
+for _name in [
+    name
+    for name in list(sys.modules)
+    if name.startswith(("flet", "gui")) or name in {"darkdetect", "sys_vars", "i18n", "i18n.lang"}
+]:
+    del sys.modules[_name]
+
+import flet as ft  # noqa: E402
+
+from gui.app import VideodlApp  # noqa: E402
+
+
+@pytest.fixture
+def page():
+    """A stand-in for Page: the app talks to it, nothing is drawn.
+
+    Not `spec=ft.Page`. The app reaches for things a Page only grows once a window
+    exists behind it. What keeps this test honest is not the fake page, it is that
+    every control the app builds is a real Flet control, asserted below.
+    """
+    page = MagicMock()
+    page.services = []
+    page.overlay = []
+    page.controls = []
+    return page
+
+
+class TestTheWindowStillBuilds:
+    def test_the_control_tree_builds_against_the_installed_flet(self, page):
+        app = VideodlApp(page)
+
+        assert app.media_link is not None
+        assert app.download_button is not None
+        assert app.quality is not None
+
+    def test_the_widgets_are_real_flet_controls(self, page):
+        """Guard the guard: if flet were mocked here, everything below would pass hollow."""
+        app = VideodlApp(page)
+
+        assert isinstance(app.media_link, ft.Control)
+        assert isinstance(app.download_progress_bar, ft.Control)
+        assert not isinstance(ft.Text, MagicMock)
+
+    def test_switching_language_touches_every_translated_label(self, page):
+        """The refresh path runs against real controls, so a renamed property raises here."""
+        app = VideodlApp(page)
+
+        app._current_language_name = "🇬🇧"
+        app._refresh_labels()
+        english = app.download_button.content
+
+        app._current_language_name = "🇫🇷"
+        app._refresh_labels()
+
+        assert app.download_button.content != english

--- a/uv.lock
+++ b/uv.lock
@@ -1125,9 +1125,9 @@ dev = [
 requires-dist = [
     { name = "darkdetect", marker = "extra == 'desktop'" },
     { name = "darkdetect", marker = "extra == 'dev'" },
-    { name = "flet", specifier = ">=0.81" },
-    { name = "flet-desktop", marker = "extra == 'desktop'", specifier = ">=0.81" },
-    { name = "flet-desktop", marker = "extra == 'dev'", specifier = ">=0.81" },
+    { name = "flet", specifier = "==0.81.0" },
+    { name = "flet-desktop", marker = "extra == 'desktop'", specifier = "==0.81.0" },
+    { name = "flet-desktop", marker = "extra == 'dev'", specifier = "==0.81.0" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pillow", marker = "extra == 'dev'" },
     { name = "pyinstaller", marker = "extra == 'dev'" },


### PR DESCRIPTION
Short answer to "should we go to Flet 0.85": **no**, and the reason is not the code.

## What 0.85 actually does to this app

I bumped it and ran the app. It dies at startup on a red error screen:

    module 'flet.controls.padding' has no attribute 'only'

The code fix is *three lines* (`ft.padding.only` is gone, `ft.Padding.only` replaces it, and it exists in 0.81 too, so I migrated them here). With those three lines, 0.85.3 runs and the window is pixel-identical. So the code is not what holds this back.

**Packaging is.** Flet 0.83 took the Flutter runtime out of the `flet-desktop` package and put it on GitHub Releases. The frozen binary drops from 76 MB to 36 MB, which sounds great, and then on first launch it does this:

    ~/.flet/client/flet-desktop-full-0.85.3   95 MB, downloaded at runtime

fetched with `urlretrieve` from GitHub, **with no checksum and no signature check**, and executed. So an Authenticode-signed binary would be downloading and running an unsigned one, and a user with no network, or behind a firewall that does not like GitHub, would have no app at all. For an app whose whole point is to be one file you double-click, that is a real regression.

None of 0.82 to 0.85 is used here: Router, `use_dialog`, Auth0, Maps, AudioRecorder, ads, CodeEditor. We would be paying that price for the 0.83 diffing speedup on a form with fifteen controls.

So: `flet==0.81.0`, pinned exactly, with the reasoning written into pyproject.toml so the next person does not have to rediscover it.

## The part that actually needed fixing

`flet>=0.81` was an open range, and Renovate's lock file maintenance runs Monday. **It would have moved us to 0.85.3 on its own, in a grouped PR that automerges on green.** And it would have been green: every test mocks flet, so the API can be renamed out from under us and the suite does not notice. `--selftest` passes too, because importing flet still works. Only opening the window fails.

Two guards:

- **`tests/test_gui_builds.py`** builds the entire control tree against the *installed* Flet, with a stand-in for `Page`. No display, milliseconds. It fails with the exact `AttributeError` above on 0.85 before the migration.
- **Flet deprecations are now errors** (`filterwarnings` in pyproject). Flet had been telling us for months:

      only() is deprecated since version 0.80.0 and will be removed in version 0.83.0

  Nobody reads a warning in a passing test run. Now it is red, versions ahead of the release that enforces it.