### PR TITLE
Trim the README and drop the name from it

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -43,13 +43,11 @@ Toutes les [versions](https://github.com/Kenshin9977/video-dl/releases) sont ici
 
 ## Sous le capot
 
-video-dl utilise le **yt-dlp officiel**, directement depuis PyPI, épinglé à une version exacte. Il ne le forke pas.
+Le yt-dlp officiel depuis PyPI, épinglé à une version exacte. Pas de fork.
 
-Cela mérite d'être dit, parce que c'était le cas avant. yt-dlp ne rapporte aucune progression pendant qu'il fait tourner FFmpeg, ni pendant qu'aria2c télécharge : ce projet maintenait donc un fork de yt-dlp tout entier pour l'ajouter, le republiait sur PyPI via un cron, et finissait par livrer un yt-dlp vieux de plusieurs mois. YouTube casse plus vite que ça.
+yt-dlp ne rapporte aucune progression pendant que FFmpeg tourne ni pendant qu'aria2c télécharge. Quatre extensions de ce dépôt l'ajoutent (`core/ytdlp_patch.py`, `core/ffmpegfd_progress.py`, `core/aria2c_progress.py`, `core/vk_extractor.py`), sur les points d'extension de yt-dlp lui-même. Une accroche qui cesse de s'appliquer coûte une barre de progression, jamais un téléchargement. La CI vérifie chaque accroche contre le yt-dlp installé, et le binaire packagé refuse de se construire si l'une d'elles ne s'applique plus.
 
-La progression tient désormais dans quatre petites extensions qui vivent dans ce dépôt (`core/ytdlp_patch.py`, `core/ffmpegfd_progress.py`, `core/aria2c_progress.py`, `core/vk_extractor.py`), accrochées à des points d'extension que yt-dlp offre déjà. Elles échouent en douceur : si une version de yt-dlp en déplace une, vous perdez une barre de progression, jamais un téléchargement. Et elles échouent bruyamment là où ça ne coûte rien : la CI vérifie chaque accroche contre le yt-dlp réellement installé, et le binaire packagé refuse de se construire si l'une d'elles ne s'applique plus.
-
-Résultat : yt-dlp est mis à jour le jour même de sa publication, un robot ouvre la pull request, la CI prouve que tout marche encore en téléchargeant un vrai fichier, et la version part toute seule.
+Les mises à jour de yt-dlp sont ouvertes, testées et publiées automatiquement.
 
 ## Compiler depuis les sources
 
@@ -73,10 +71,9 @@ uv run pyinstaller specs/Windows-video-dl.spec   # ou macOS-, ou Linux-
 
 ## Signature du code
 
-Le binaire Windows est signé en Authenticode et horodaté, avec un certificat Certum Open Source Code Signing délivré à Rogelio MENDOZA. C'est ce nom que Windows affiche. Le certificat ne passe jamais par la CI : le build envoie le binaire à un hôte de signature via SSH, et la publication est refusée si Windows ne déclare pas la signature valide.
+Le binaire Windows est signé en Authenticode et horodaté avec un certificat Certum Open Source Code Signing. Le certificat ne passe jamais par la CI : le build envoie le binaire à un hôte de signature via SSH, et la publication est refusée si Windows ne déclare pas la signature valide.
 
-- Commits et relecture : Rogelio MENDOZA ([Kenshin9977](https://github.com/Kenshin9977))
-- Approbation : Rogelio MENDOZA ([Kenshin9977](https://github.com/Kenshin9977))
+- Commits, relecture et approbation : [Kenshin9977](https://github.com/Kenshin9977)
 
 ## Vie privée
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,11 @@ Every [release](https://github.com/Kenshin9977/video-dl/releases) is here. The a
 
 ## Under the hood
 
-video-dl uses **upstream yt-dlp**, straight from PyPI, pinned to an exact version. It does not fork it.
+Upstream yt-dlp from PyPI, pinned to an exact version. No fork.
 
-That is worth saying because it used to. yt-dlp reports no progress while it runs FFmpeg, or while aria2c is doing the downloading, so this project carried a fork of the whole of yt-dlp to add it, republished it to PyPI on a cron, and ended up shipping a yt-dlp that was months behind upstream. YouTube breaks faster than that.
+yt-dlp reports no progress while FFmpeg runs or while aria2c downloads. Four extensions in this repository add it (`core/ytdlp_patch.py`, `core/ffmpegfd_progress.py`, `core/aria2c_progress.py`, `core/vk_extractor.py`), on yt-dlp's own extension points. A hook that stops applying costs a progress bar, never a download. CI checks each hook against the installed yt-dlp, and the packaged binary refuses to build if one no longer applies.
 
-Progress reporting is now four small extensions that live in this repository (`core/ytdlp_patch.py`, `core/ffmpegfd_progress.py`, `core/aria2c_progress.py`, `core/vk_extractor.py`), hooked onto extension points yt-dlp already has. They fail soft: if a yt-dlp release moves one of them, you lose a progress bar, never a download. And they fail loudly where it costs nothing: CI asserts every hook against the yt-dlp that is actually installed, and the packaged binary refuses to build if one of them no longer applies.
-
-So yt-dlp gets bumped the day it publishes, a robot opens the pull request, CI proves it still works by downloading a real file, and the release ships itself.
+yt-dlp bumps are opened, tested and released automatically.
 
 ## Build from source
 
@@ -73,10 +71,9 @@ uv run pyinstaller specs/Windows-video-dl.spec   # or macOS-, or Linux-
 
 ## Code signing
 
-The Windows binary is Authenticode-signed and timestamped, with a Certum Open Source Code Signing certificate issued to Rogelio MENDOZA. Windows will show that name. The certificate never touches CI: the build streams the binary to a signing host over SSH, and the release refuses to publish if Windows does not report the signature as valid.
+The Windows binary is Authenticode-signed and timestamped with a Certum Open Source Code Signing certificate. The certificate never touches CI: the build streams the binary to a signing host over SSH, and the release refuses to publish if Windows does not report the signature as valid.
 
-- Committers and reviewers: Rogelio MENDOZA ([Kenshin9977](https://github.com/Kenshin9977))
-- Approvers: Rogelio MENDOZA ([Kenshin9977](https://github.com/Kenshin9977))
+- Committers, reviewers and approvers: [Kenshin9977](https://github.com/Kenshin9977)
 
 ## Privacy
 


### PR DESCRIPTION
Cuts the fork backstory and the narration out of the 'Under the hood' section: what is left is the facts (upstream yt-dlp pinned exactly, the four extensions, what breaks and what does not, automated bumps).

Removes the author name from both READMEs. It stays in LICENSE (copyright) and in pyproject.toml, where it was added on purpose for Certum's code-signing certificate verification, so I left both alone.