### PR TITLE
Sign the APK with a release key instead of Android's debug key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,12 +264,30 @@ jobs:
           cp "$ANDROID_LIBS/qjs" "$JNILIBS/libqjs.so"
           cp "$ANDROID_LIBS/aria2c" "$JNILIBS/libaria2c.so"
 
+      # Without a signing config, Flutter falls back to the Android debug key, which
+      # is public and shared by every debug build on earth. An APK signed with it
+      # accrues no Play Protect reputation, and Android refuses an update signed by a
+      # different key, so shipping on the debug key means every user has to uninstall
+      # to ever get off it. Sign with the release key; the check after the build
+      # refuses to publish if this ever silently falls back again.
+      - name: Decode the release keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is unset, and an unsigned release APK is not worth publishing"
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+
       # arm64-v8a only, on purpose. The native libs above are injected into that
       # ABI alone, and ffmpeg, aria2c and qjs are only built for aarch64 upstream,
       # so an armeabi-v7a or x86_64 APK would install and then fail at the first
       # download or mux. Publishing one working APK beats publishing three of
       # which two are broken.
       - name: Build APK
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
         run: |
           uv run flet build apk \
             --project video-dl \
@@ -285,7 +303,11 @@ jobs:
               htmlcov .tox build Makefile "*.icns" "*.ico" "*.spec" \
               check_results.txt test_outdir android_libs \
             --android-permissions INTERNET=True WRITE_EXTERNAL_STORAGE=True READ_EXTERNAL_STORAGE=True MANAGE_EXTERNAL_STORAGE=True \
-            --android-adaptive-icon-background "#7C3AED"
+            --android-adaptive-icon-background "#7C3AED" \
+            --android-signing-key-store "$RUNNER_TEMP/release.jks" \
+            --android-signing-key-store-password "$ANDROID_KEYSTORE_PASSWORD" \
+            --android-signing-key-password "$ANDROID_KEYSTORE_PASSWORD" \
+            --android-signing-key-alias video-dl
 
       - name: Keep only the ABI we ship
         run: |
@@ -299,13 +321,40 @@ jobs:
           mv "${apk[0]}" release_apk/video-dl-arm64-v8a.apk
           ls -lh release_apk/
 
+      # The fingerprint of the release key, in the clear on purpose: it is the same
+      # value registered with the Android Developer Console, and it is public by
+      # construction, every installed APK carries the certificate it was signed with.
+      # Pinning it here is what makes the signature mean something. A build signed
+      # with anything else, the debug key included, does not leave this job.
+      - name: Verify the APK signature
+        env:
+          EXPECTED_SHA256: "8A:67:2B:69:DA:85:AE:7C:33:CE:61:F1:CC:E1:A8:99:9B:F7:A7:22:F9:18:36:AE:72:6B:02:45:85:E7:69:30"
+        run: |
+          apksigner=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
+          "$apksigner" verify --print-certs --verbose release_apk/video-dl-arm64-v8a.apk | tee certs.txt
+          grep -qx "Verified using v2 scheme (APK Signature Scheme v2): true" certs.txt \
+            || { echo "::error::APK is not v2-signed"; exit 1; }
+          actual=$(grep -m1 "Signer #1 certificate SHA-256 digest:" certs.txt | awk '{print $NF}')
+          expected=$(echo "$EXPECTED_SHA256" | tr -d ': ' | tr 'A-Z' 'a-z')
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::APK signed with the wrong key: got $actual, expected $expected"
+            exit 1
+          fi
+
       - uses: actions/upload-artifact@v7
         with:
           name: android-apk
           path: release_apk/video-dl-arm64-v8a.apk
 
+  # Everything up to here builds and verifies. Everything from here publishes, and
+  # publishing only ever makes sense for a tag: the version is read out of the ref
+  # (`${GITHUB_REF_NAME#v}`), and the tufup channel's version counters only go up.
+  # A workflow_dispatch on a branch used to walk straight into the release job and
+  # publish "master". Now it stops here, which also makes a dispatch on a branch the
+  # way to dry-run a build. auto-release dispatches on the tag ref, so it is unaffected.
   sign:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -395,6 +444,7 @@ jobs:
 
   release:
     needs: [build, android, sign]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,7 +334,15 @@ jobs:
           "$apksigner" verify --print-certs --verbose release_apk/video-dl-arm64-v8a.apk | tee certs.txt
           grep -qx "Verified using v2 scheme (APK Signature Scheme v2): true" certs.txt \
             || { echo "::error::APK is not v2-signed"; exit 1; }
-          actual=$(grep -m1 "Signer #1 certificate SHA-256 digest:" certs.txt | awk '{print $NF}')
+          # Match on "certificate SHA-256 digest:" alone. --verbose labels the line
+          # "V2 Signer:" where plain --print-certs labels it "Signer #1", and only
+          # the certificate lines carry that phrase, the public key ones say
+          # "public key SHA-256 digest". Anchoring on the label matched neither.
+          actual=$(grep -m1 "certificate SHA-256 digest:" certs.txt | awk '{print $NF}')
+          if [ -z "$actual" ]; then
+            echo "::error::could not read a signer fingerprint out of apksigner's output"
+            exit 1
+          fi
           expected=$(echo "$EXPECTED_SHA256" | tr -d ': ' | tr 'A-Z' 'a-z')
           if [ "$actual" != "$expected" ]; then
             echo "::error::APK signed with the wrong key: got $actual, expected $expected"

--- a/README.fr.md
+++ b/README.fr.md
@@ -73,6 +73,8 @@ uv run pyinstaller specs/Windows-video-dl.spec   # ou macOS-, ou Linux-
 
 Le binaire Windows est signé en Authenticode et horodaté avec un certificat Certum Open Source Code Signing. Le certificat ne passe jamais par la CI : le build envoie le binaire à un hôte de signature via SSH, et la publication est refusée si Windows ne déclare pas la signature valide.
 
+L'APK est signé avec une clé de release, et le build relit la signature dans l'APK terminé : la publication est refusée si l'empreinte n'est pas celle attendue. Android n'a pas d'autorité de certification — tous les APK sont auto-signés — donc il n'y a rien à acheter chez Certum ici, et la réputation s'attache à la clé de signature elle-même. D'où l'accueil de Play Protect à la première installation, *Play Protect n'a jamais vu d'appli de ce développeur avant* : c'est une remarque sur l'âge de la clé, pas sur l'application. Faites *Plus de détails → Installer quand même*. Le message ne disparaît que pour les applications du Play Store, et le Play Store n'accepte pas les applications qui téléchargent des vidéos depuis YouTube.
+
 - Commits, relecture et approbation : [Kenshin9977](https://github.com/Kenshin9977)
 
 ## Vie privée

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ uv run pyinstaller specs/Windows-video-dl.spec   # or macOS-, or Linux-
 
 The Windows binary is Authenticode-signed and timestamped with a Certum Open Source Code Signing certificate. The certificate never touches CI: the build streams the binary to a signing host over SSH, and the release refuses to publish if Windows does not report the signature as valid.
 
+The APK is signed with a release key, and the build reads the signature back out of the finished APK and refuses to publish unless its fingerprint is the pinned one. Android has no certificate authority — every APK is self-signed — so there is nothing to buy from Certum here, and reputation attaches to the signing key itself. Which is why Play Protect greets a first install with *Play Protect has never seen this developer before*: it is a statement about the key's age, not about the app. Tap *More details → Install anyway*. The warning goes away only for apps on the Play Store, and the Play Store does not accept apps that download videos from YouTube.
+
 - Committers, reviewers and approvers: [Kenshin9977](https://github.com/Kenshin9977)
 
 ## Privacy


### PR DESCRIPTION
`flet build apk` was given no signing config, so Flutter fell through to its default: the public Android debug key, the one every debug build on earth shares. Nothing good comes of shipping on it. Reputation cannot accrue on a key that is not yours, Android refuses an update signed by a different key — so every day on the debug key raised the cost of leaving it — and Google's developer verification, mandatory for sideloaded apps from 2026, keys the package name to the fingerprint of the signing key.

So sign the APK with a real release key, kept in `ANDROID_KEYSTORE_BASE64` and decoded at build time. If the secret is missing the job now stops rather than quietly falling back, which is how this went unnoticed in the first place.

A signing step is only worth what its check is worth, so the build reads the signature back out of the finished APK with `apksigner` and compares the signer's SHA-256 against the fingerprint pinned in the workflow. Wrong key, debug key, no key: the APK does not leave the job. The fingerprint is in the clear on purpose — it is public by construction, every installed APK carries the certificate it was signed with, and it is the same value registered with the Android Developer Console, so pinning it here keeps one source of truth instead of two.

`sign` and `release` move behind a tag check while here. Both read the version out of the ref (`${GITHUB_REF_NAME#v}`) and push the tufup channel's counters forward, and neither makes sense off a tag: a `workflow_dispatch` on a branch would have walked into the release job and published a release named `master`. `auto-release` dispatches on the tag ref, so it is unaffected — and a dispatch on a branch now builds and verifies and stops, which is how this PR was dry-run ([green run](https://github.com/Kenshin9977/video-dl/actions/runs/29346679497), APK out signed `CN=Kenshin9977, O=video-dl, C=FR`, RSA 4096).

Out of band, and worth writing down: the debug-signed APKs were pulled from all 9 releases that carried them (~40 downloads between them), `com.videodl.video_dl` is registered with the Android Developer Console against this key's fingerprint, and anyone who installed an old APK has to uninstall before installing this one — Android will not take the update across a key change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
