### PR TITLE
Sign and notarize the macOS app with Developer ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,15 +128,37 @@ jobs:
             | awk '/Developer ID Application/{print $2; exit}')
           test -n "$IDENTITY"
 
-          # Sign inner-out: every Mach-O with the hardened runtime, deepest first, so
-          # each seal is valid when the enclosing bundle is sealed over it. The main
-          # executable and bundle carry the entitlements; dylibs neither need nor
-          # accept them.
-          find "$APP" -type f | while IFS= read -r f; do
-            if file "$f" | grep -q 'Mach-O'; then echo "$f"; fi
-          done | awk '{print gsub(/\//,"/"), $0}' | sort -rn | cut -d' ' -f2- | while IFS= read -r f; do
-            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$f"
-          done
+          # Sign every Mach-O under a directory tree, inner-out (deepest first) so each
+          # seal is valid when its enclosing bundle is sealed over it. Runtime on all;
+          # the caller re-signs bundle main-executables with entitlements afterward.
+          sign_tree() {
+            find "$1" -type f | while IFS= read -r f; do
+              if file "$f" | grep -q 'Mach-O'; then echo "$f"; fi
+            done | awk '{print gsub(/\//,"/"), $0}' | sort -rn | cut -d' ' -f2- \
+            | while IFS= read -r f; do
+              codesign --force --options runtime --timestamp --sign "$IDENTITY" "$f"
+            done
+          }
+
+          # flet ships the Flutter UI as an unsigned Flet.app inside this tarball. find
+          # never sees it (it is compressed), but the notary service unpacks the archive
+          # and rejects the whole submission over it. Extract, sign Flet.app, repack —
+          # before the outer app is sealed over the tarball's bytes below.
+          FLET_TGZ=$(find "$APP/Contents" -name 'flet-macos.tar.gz' | head -1)
+          if [ -n "$FLET_TGZ" ]; then
+            work="$RUNNER_TEMP/flet"
+            rm -rf "$work"; mkdir -p "$work"
+            tar -xzf "$FLET_TGZ" -C "$work"
+            sign_tree "$work"
+            FLET_APP=$(find "$work" -maxdepth 2 -name 'Flet.app' | head -1)
+            codesign --force --options runtime --timestamp \
+              --entitlements specs/macos-entitlements.plist --sign "$IDENTITY" "$FLET_APP"
+            tar -czf "$FLET_TGZ" -C "$work" $(ls "$work")
+          fi
+
+          # The main executable and bundle carry the entitlements; dylibs neither need
+          # nor accept them.
+          sign_tree "$APP"
           codesign --force --options runtime --timestamp \
             --entitlements specs/macos-entitlements.plist \
             --sign "$IDENTITY" "$APP"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,10 @@ jobs:
 
           APP=dist/video-dl.app
           dyld=$(dirname "$(find "$APP" -name 'pyexpat*.so' | head -1)")
-          cp /tmp/expat-out/lib/libexpat.*.dylib "$dyld/libexpat.1.dylib"
+          # -type f picks the real dylib, not the libexpat.1.dylib / libexpat.dylib
+          # symlinks make install also drops next to it.
+          src=$(find /tmp/expat-out/lib -name 'libexpat.*.dylib' -type f | head -1)
+          cp "$src" "$dyld/libexpat.1.dylib"
           chmod u+w "$dyld/libexpat.1.dylib"
           install_name_tool -id @loader_path/libexpat.1.dylib "$dyld/libexpat.1.dylib"
           codesign --force --sign - "$dyld/libexpat.1.dylib"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    # Hoisted to the job so the signing step's `if:` can test it. A step's own
+    # Hoisted to the job so the signing steps' `if:` can test them. A step's own
     # `env:` is not visible to its own `if:` — the condition is evaluated first —
     # and the `secrets` context is not available there at all.
     env:
       SIGN_SSH_HOST: ${{ secrets.SIGN_SSH_HOST }}
+      MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
 
     steps:
       - uses: actions/checkout@v7
@@ -92,6 +93,66 @@ jobs:
         shell: bash
         run: mv dist/video-dl "${{ matrix.artifact }}"
 
+      # Developer ID signing + notarization, the non-App-Store path. It runs before
+      # the DMG is built (the app has to be signed and stapled first) and, like the
+      # Windows signing below, before the artifact is uploaded, so the tufup `sign`
+      # job hashes signed bytes. Skipped, non-fatally, when the cert secret is
+      # absent — a fork still builds green, just unsigned.
+      #
+      # The keychain, notary key and identity set up here persist on the runner for
+      # the DMG-signing step in the same job.
+      - name: Sign and notarize the app (macOS)
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        env:
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
+        run: |
+          set -euo pipefail
+          APP=dist/video-dl.app
+
+          # An ephemeral keychain with a random password, torn down with the runner.
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PW=$(uuidgen)
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          echo "$MACOS_CERT_P12" | base64 -d > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$MACOS_CERT_PASSWORD" \
+            -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+          # Put it on the search list so codesign and notarytool find the identity.
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | awk '/Developer ID Application/{print $2; exit}')
+          test -n "$IDENTITY"
+
+          # Sign inner-out: every Mach-O with the hardened runtime, deepest first, so
+          # each seal is valid when the enclosing bundle is sealed over it. The main
+          # executable and bundle carry the entitlements; dylibs neither need nor
+          # accept them.
+          find "$APP" -type f | while IFS= read -r f; do
+            if file "$f" | grep -q 'Mach-O'; then echo "$f"; fi
+          done | awk '{print gsub(/\//,"/"), $0}' | sort -rn | cut -d' ' -f2- | while IFS= read -r f; do
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$f"
+          done
+          codesign --force --options runtime --timestamp \
+            --entitlements specs/macos-entitlements.plist \
+            --sign "$IDENTITY" "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
+
+          # notarytool wants an archive, not a raw .app. Zip it, submit, then staple
+          # the ticket onto the .app itself so first launch works offline.
+          echo "$MACOS_NOTARY_KEY" | base64 -d > "$RUNNER_TEMP/notary.p8"
+          ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/app.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/app.zip" \
+            --key "$RUNNER_TEMP/notary.p8" \
+            --key-id "$MACOS_NOTARY_KEY_ID" \
+            --issuer "$MACOS_NOTARY_ISSUER" \
+            --wait
+          xcrun stapler staple "$APP"
+
       - name: Package artifact (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -99,6 +160,31 @@ jobs:
             -srcfolder dist/video-dl.app \
             -ov -format UDZO \
             "${{ matrix.artifact }}"
+
+      # Sign, notarize and staple the DMG too: the .app inside is already stapled,
+      # but stapling the DMG means the download the user actually double-clicks
+      # passes Gatekeeper offline as well. Reuses the keychain and notary key the
+      # app-signing step left on the runner.
+      - name: Sign and notarize the DMG (macOS)
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        env:
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
+        run: |
+          set -euo pipefail
+          DMG="${{ matrix.artifact }}"
+          IDENTITY=$(security find-identity -v -p codesigning "$RUNNER_TEMP/signing.keychain-db" \
+            | awk '/Developer ID Application/{print $2; exit}')
+          codesign --force --timestamp --sign "$IDENTITY" "$DMG"
+          xcrun notarytool submit "$DMG" \
+            --key "$RUNNER_TEMP/notary.p8" \
+            --key-id "$MACOS_NOTARY_KEY_ID" \
+            --issuer "$MACOS_NOTARY_ISSUER" \
+            --wait
+          xcrun stapler staple "$DMG"
+          # Gatekeeper's own verdict, or the release does not go out. --deep for the
+          # app is deprecated, but for a DMG spctl assesses the mounted contents.
+          spctl --assess --type open --context context:primary-signature -vv "$DMG"
 
       # Authenticode-sign here, inside the build job, BEFORE the artifact is
       # uploaded — the `sign` job below hashes these artifacts into the tufup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,52 @@ jobs:
         if: runner.os == 'Linux'
         run: ./dist/video-dl --selftest
 
+      # Python 3.14 (python-build-standalone) builds the stdlib's pyexpat against
+      # CPython's vendored expat 2.7.2+, but links it to the system
+      # /usr/lib/libexpat.1.dylib, which on macOS is older and lacks
+      # XML_SetAllocTrackerActivationThreshold. Reading any XML or .plist then crashes
+      # the app on machines whose system expat is too old (macOS 26 among them). Ship
+      # our own expat and point the stdlib .so files at it, so the app stops depending
+      # on whatever expat the OS happens to carry. Runs for every macOS build, signed
+      # or not; the signing step below re-signs the .so files it rewrites here.
+      - name: Bundle a current libexpat (macOS)
+        if: runner.os == 'macOS'
+        env:
+          EXPAT_VERSION: "2.7.5"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/expat.tar.gz \
+            "https://github.com/libexpat/libexpat/releases/download/R_${EXPAT_VERSION//./_}/expat-${EXPAT_VERSION}.tar.gz"
+          tar xf /tmp/expat.tar.gz -C /tmp
+          (cd "/tmp/expat-${EXPAT_VERSION}" && \
+            ./configure --prefix=/tmp/expat-out --without-docbook --without-examples --without-tests >/dev/null && \
+            make -j3 >/dev/null && make install >/dev/null)
+
+          APP=dist/video-dl.app
+          dyld=$(dirname "$(find "$APP" -name 'pyexpat*.so' | head -1)")
+          cp /tmp/expat-out/lib/libexpat.*.dylib "$dyld/libexpat.1.dylib"
+          chmod u+w "$dyld/libexpat.1.dylib"
+          install_name_tool -id @loader_path/libexpat.1.dylib "$dyld/libexpat.1.dylib"
+          codesign --force --sign - "$dyld/libexpat.1.dylib"
+
+          # pyexpat and _elementtree both link expat, both live next to it in
+          # lib-dynload, so @loader_path resolves for each. Ad-hoc re-sign here so an
+          # unsigned fork build still loads them; the Developer ID step re-signs later.
+          repointed=0
+          while IFS= read -r so; do
+            if otool -L "$so" | grep -q '/usr/lib/libexpat.1.dylib'; then
+              chmod u+w "$so"
+              install_name_tool -change /usr/lib/libexpat.1.dylib @loader_path/libexpat.1.dylib "$so"
+              codesign --force --sign - "$so"
+              echo "repointed $(basename "$so")"
+              repointed=$((repointed + 1))
+            fi
+          done < <(find "$APP" -name '*.so')
+          if [ "$repointed" -eq 0 ]; then
+            echo "::error::no .so linked the system libexpat; the bundling assumption changed"
+            exit 1
+          fi
+
       - name: Smoke test (macOS)
         if: runner.os == 'macOS'
         run: ./dist/video-dl.app/Contents/MacOS/video-dl --selftest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,11 +168,7 @@ jobs:
           # the ticket onto the .app itself so first launch works offline.
           echo "$MACOS_NOTARY_KEY" | base64 -d > "$RUNNER_TEMP/notary.p8"
           ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/app.zip"
-          xcrun notarytool submit "$RUNNER_TEMP/app.zip" \
-            --key "$RUNNER_TEMP/notary.p8" \
-            --key-id "$MACOS_NOTARY_KEY_ID" \
-            --issuer "$MACOS_NOTARY_ISSUER" \
-            --wait
+          NOTARY_KEY="$RUNNER_TEMP/notary.p8" bash tools/notarize.sh "$RUNNER_TEMP/app.zip"
           xcrun stapler staple "$APP"
 
       - name: Package artifact (macOS)
@@ -198,11 +194,7 @@ jobs:
           IDENTITY=$(security find-identity -v -p codesigning "$RUNNER_TEMP/signing.keychain-db" \
             | awk '/Developer ID Application/{print $2; exit}')
           codesign --force --timestamp --sign "$IDENTITY" "$DMG"
-          xcrun notarytool submit "$DMG" \
-            --key "$RUNNER_TEMP/notary.p8" \
-            --key-id "$MACOS_NOTARY_KEY_ID" \
-            --issuer "$MACOS_NOTARY_ISSUER" \
-            --wait
+          NOTARY_KEY="$RUNNER_TEMP/notary.p8" bash tools/notarize.sh "$DMG"
           xcrun stapler staple "$DMG"
           # Gatekeeper's own verdict, or the release does not go out. --deep for the
           # app is deprecated, but for a DMG spctl assesses the mounted contents.

--- a/core/aria2c_progress.py
+++ b/core/aria2c_progress.py
@@ -67,7 +67,15 @@ def install() -> bool:
         return original_call_downloader(self, tmpfilename, info_dict)
 
     def _make_cmd(self, tmpfilename, info_dict):
-        return original_make_cmd(self, tmpfilename, info_dict) + rpc_flags(info_dict)
+        cmd = original_make_cmd(self, tmpfilename, info_dict)
+        flags = rpc_flags(info_dict)
+        if not flags:
+            return cmd
+        # Inject right after the executable, not at the end. yt-dlp puts the URL last,
+        # and aria2 stops treating tokens as options once it hits the URL, so flags
+        # appended after it are read as URIs ("Unrecognized URI: --enable-rpc"). Before
+        # the URL they are always parsed as options.
+        return [cmd[0], *flags, *cmd[1:]]
 
     def _call_process(self, cmd, info_dict):
         if "__rpc" not in info_dict:

--- a/core/ydl_opts.py
+++ b/core/ydl_opts.py
@@ -27,8 +27,11 @@ def build_file_opts(
     }
     if indices_enabled:
         opts["playlist_items"] = indices_value or 1
-    if ff_path.get("ffmpeg") != "ffmpeg":
-        opts["ffmpeg_location"] = ff_path["ffmpeg"]
+    # .get() throughout: an empty ff_path used to reach ff_path["ffmpeg"] and raise
+    # KeyError. "ffmpeg" means "on PATH", so no explicit location is needed.
+    ffmpeg = ff_path.get("ffmpeg")
+    if ffmpeg and ffmpeg != "ffmpeg":
+        opts["ffmpeg_location"] = ffmpeg
     return opts
 
 

--- a/deps.py
+++ b/deps.py
@@ -42,7 +42,7 @@ FFMPEG_ANDROID_ASSET_PATTERN = "*androidarm64-gpl-shared.tar.xz"
 # same tag for both, or the two platforms ship different binaries.
 # Same again: `release-2.0.1` is a version wearing a prefix, and `loose` skipped it.
 # renovate: datasource=github-releases depName=Kenshin9977/aria2 versioning=regex:^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-ARIA2_TAG = "release-2.0.1"
+ARIA2_TAG = "release-2.0.2"
 ARIA2_REPO = "Kenshin9977/aria2"
 
 # QuickJS, compiled from source for Android. Pinned to a commit: the project has no

--- a/gui/app.py
+++ b/gui/app.py
@@ -668,7 +668,12 @@ class VideodlApp:
         Returns:
             dict: yt-dlp options
         """
-        self.ydl_opts = {"verbose": True}
+        # Download HLS/DASH fragments in parallel — the biggest speed lever across
+        # every site, since most HD formats are segmented and yt-dlp fetches one
+        # fragment at a time by default. 4 is the safe sweet spot: a real speedup
+        # without the 429/403 rate-limiting that a single IP draws at 16+, and
+        # yt-dlp retries any fragment that does get throttled (fragment_retries=10).
+        self.ydl_opts = {"verbose": True, "concurrent_fragment_downloads": 4}
         if sys_vars.QJS_PATH:
             self.ydl_opts["js_runtimes"] = {"quickjs": {"path": sys_vars.QJS_PATH}}
         self._gen_file_opts()
@@ -692,6 +697,10 @@ class VideodlApp:
             and "download_ranges" not in self.ydl_opts
         ):
             self.ydl_opts["external_downloader"] = {"http": sys_vars.ARIA2C_PATH}
+            # 16 connections with a 1M split is aria2's standard multi-connection
+            # setup, and the whole reason to use it here: on the permissive direct-HTTP
+            # servers this path is reserved for, it multiplies throughput.
+            self.ydl_opts["external_downloader_args"] = {"aria2c": ["-x", "16", "-s", "16", "-k", "1M"]}
         return self.ydl_opts
 
     def _gen_file_opts(self):

--- a/gui/app.py
+++ b/gui/app.py
@@ -40,6 +40,12 @@ from flet import (
 from yt_dlp.utils import DownloadCancelled as YtdlpDownloadCancelled
 
 import runtime
+
+# Imported as a module, not `from sys_vars import FF_PATH, ...`: init_paths()
+# reassigns these globals at startup, and a bare import would freeze the empty
+# pre-init values into this module if gui.app is ever imported before init_paths
+# runs (the macOS bundle patch does exactly that).
+import sys_vars
 from core.download import create_ydl, download
 from core.error_report import ErrorReport, build_error_report
 from core.progress import compute_progress, parse_quantity, parse_speed, timecodes_are_valid
@@ -84,7 +90,6 @@ from i18n.lang import (
     set_current_language,
 )
 from i18n.lang import get_text as gt
-from sys_vars import ARIA2C_PATH, FF_PATH, QJS_PATH
 from utils.parse_util import simple_traverse, validate_url
 from utils.sponsor_block_dict import CATEGORIES
 from utils.sys_utils import APP_VERSION, PLATFORM, get_default_download_path
@@ -649,8 +654,8 @@ class VideodlApp:
             dict: yt-dlp options
         """
         self.ydl_opts = {"verbose": True}
-        if QJS_PATH:
-            self.ydl_opts["js_runtimes"] = {"quickjs": {"path": QJS_PATH}}
+        if sys_vars.QJS_PATH:
+            self.ydl_opts["js_runtimes"] = {"quickjs": {"path": sys_vars.QJS_PATH}}
         self._gen_file_opts()
         self._gen_av_opts()
         self._gen_ffmpeg_opts()
@@ -662,12 +667,12 @@ class VideodlApp:
         # Only use it for generic http/https downloads where multi-connection helps
         has_cookies = "cookiesfrombrowser" in self.ydl_opts or "cookiesfile" in self.ydl_opts
         if (
-            ARIA2C_PATH
+            sys_vars.ARIA2C_PATH
             and not has_cookies
             and "external_downloader" not in self.ydl_opts
             and "download_ranges" not in self.ydl_opts
         ):
-            self.ydl_opts["external_downloader"] = {"http": ARIA2C_PATH}
+            self.ydl_opts["external_downloader"] = {"http": sys_vars.ARIA2C_PATH}
         return self.ydl_opts
 
     def _gen_file_opts(self):
@@ -677,7 +682,7 @@ class VideodlApp:
                 dest_folder=str(self.download_path_text.value),
                 indices_enabled=bool(self.indices.value),
                 indices_value=self.indices_selected.value,
-                ff_path=FF_PATH,
+                ff_path=sys_vars.FF_PATH,
                 progress_hook=self._update_download_bar,
                 postprocessor_hook=self._update_process_bar,
             )
@@ -1044,8 +1049,8 @@ class VideodlApp:
                 self.video_preview.visible = True
                 self._safe_update()
                 opts = {"quiet": True, "no_warnings": True, "noplaylist": True}
-            if QJS_PATH:
-                opts["js_runtimes"] = {"quickjs": {"path": QJS_PATH}}
+            if sys_vars.QJS_PATH:
+                opts["js_runtimes"] = {"quickjs": {"path": sys_vars.QJS_PATH}}
             with YoutubeDL(opts) as ydl:
                 info = ydl.extract_info(url, download=False)
             if info is None:
@@ -1558,7 +1563,7 @@ class VideodlApp:
         status_cb = _AppStatusCallback(self)
         ydl_opts = self._gen_ydl_opts()
         try:
-            ydl = await asyncio.to_thread(create_ydl, ydl_opts, status_cb, FF_PATH)
+            ydl = await asyncio.to_thread(create_ydl, ydl_opts, status_cb, sys_vars.FF_PATH)
         except Exception as e:
             report = build_error_report(e)
             logger.error(report.short_message)
@@ -1594,7 +1599,7 @@ class VideodlApp:
                 url=url or self.media_link.value,
                 audio_only=bool(self.audio_only.value),
                 target_vcodec=target_vcodec,
-                ff_path=FF_PATH,
+                ff_path=sys_vars.FF_PATH,
                 ydl_opts=ydl_opts,
             )
             try:

--- a/gui/app.py
+++ b/gui/app.py
@@ -110,6 +110,21 @@ def _urls_share_host(urls: list[str]) -> bool:
     return len(hosts) == 1
 
 
+def _aria2c_would_be_throttled(url: str | None) -> bool:
+    """True for hosts that throttle aria2c's connections far below the native
+    downloader. Measured on a YouTube short: ~100 KB/s via aria2c vs ~27 MB/s
+    native, because Google throttles aria2c's request pattern. yt-dlp's own
+    downloader handles these; aria2c only wins on plain direct HTTP. Extend the
+    tuple as other sites turn up.
+    """
+    if not url:
+        return False
+    from urllib.parse import urlparse
+
+    host = (urlparse(url).hostname or "").lower()
+    return host.endswith(("youtube.com", "youtu.be", "googlevideo.com"))
+
+
 def _system_is_dark(page: ft.Page) -> bool:
     """OS dark mode via Flet's own brightness.
 
@@ -663,12 +678,16 @@ class VideodlApp:
         self._gen_browser_opts()
         self._gen_proxy_opts()
         self._gen_sponsor_block_opts()
-        # aria2c is slower than native on sites with auth/cookies (YouTube, etc.)
-        # Only use it for generic http/https downloads where multi-connection helps
+        # aria2c only wins on plain direct HTTP where its many connections help. On
+        # sites that throttle it (YouTube) or need cookies, the native downloader is
+        # faster, so leave those to yt-dlp. The opts are shared across the whole batch,
+        # so one throttled URL opts the batch out.
         has_cookies = "cookiesfrombrowser" in self.ydl_opts or "cookiesfile" in self.ydl_opts
+        urls = [self.media_link.value, *self._url_queue]
         if (
             sys_vars.ARIA2C_PATH
             and not has_cookies
+            and not any(_aria2c_would_be_throttled(u) for u in urls)
             and "external_downloader" not in self.ydl_opts
             and "download_ranges" not in self.ydl_opts
         ):

--- a/gui/app.py
+++ b/gui/app.py
@@ -12,18 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import flet as ft
-
-try:
-    from darkdetect import isDark
-except (ImportError, ValueError):
-    # ValueError: darkdetect parses platform.mac_ver() at import and blows up on the
-    # empty string Python 3.14 hands it on macOS 26. main.py patches mac_ver so this
-    # normally imports fine; this stays as a seatbelt so a version quirk can never
-    # take the whole GUI down with it.
-    def isDark():
-        return True
-
-
 from flet import (
     Button,
     Checkbox,
@@ -117,6 +105,16 @@ def _urls_share_host(urls: list[str]) -> bool:
     return len(hosts) == 1
 
 
+def _system_is_dark(page: ft.Page) -> bool:
+    """OS dark mode via Flet's own brightness.
+
+    Replaces the unmaintained darkdetect, which parsed platform.mac_ver() at import
+    and crashed on the empty string Python 3.14 hands it on macOS 26. Flet already
+    knows the OS brightness, so ask it instead of shipping a dependency for it.
+    """
+    return page.platform_brightness == ft.Brightness.DARK
+
+
 DISABLED_COLOR = Colors.ON_INVERSE_SURFACE
 
 
@@ -160,7 +158,7 @@ class _AppStatusCallback:
 
 class VideodlApp:
     def __init__(self, page: Page, *, mobile: bool = False):
-        is_dark = bool(isDark())
+        is_dark = _system_is_dark(page)
         self.page = page
         self._mobile = mobile
         self.page.title = "Video-dl"
@@ -601,7 +599,7 @@ class VideodlApp:
             hint_text=gt(GF.queue_dialog_hint),
             expand=True,
         )
-        self.tomlconfig = VideodlConfig()
+        self.tomlconfig = VideodlConfig(default_dark=_system_is_dark(self.page))
 
     async def _pick_directory(self, e):
         result = await self.file_picker.get_directory_path()

--- a/gui/app.py
+++ b/gui/app.py
@@ -15,8 +15,11 @@ import flet as ft
 
 try:
     from darkdetect import isDark
-except ImportError:
-
+except (ImportError, ValueError):
+    # ValueError: darkdetect parses platform.mac_ver() at import and blows up on the
+    # empty string Python 3.14 hands it on macOS 26. main.py patches mac_ver so this
+    # normally imports fine; this stays as a seatbelt so a version quirk can never
+    # take the whole GUI down with it.
     def isDark():
         return True
 

--- a/gui/config.py
+++ b/gui/config.py
@@ -14,14 +14,6 @@ from i18n.lang import get_available_languages_name, get_current_language_name, s
 from i18n.lang import get_text as gt
 from utils.sys_utils import get_default_browser, get_default_download_path
 
-try:
-    from darkdetect import isDark
-except ImportError:
-
-    def isDark():
-        return True
-
-
 _config_filename: str | None = None
 USER_OPTIONS = "User options"
 
@@ -55,7 +47,10 @@ CK_PROXY = "Proxy"
 
 
 class VideodlConfig:
-    def __init__(self):
+    def __init__(self, default_dark: bool = True):
+        # Only used to seed the theme when no config exists yet; the user's choice
+        # is persisted from then on. Stored so _load()'s repair path can reach it too.
+        self._default_dark = default_dark
         if isfile(_get_config_filename()):
             self.config = self._load()
         else:
@@ -70,7 +65,7 @@ class VideodlConfig:
         config = {
             USER_OPTIONS: {
                 CK_LANGUAGE: get_current_language_name(),
-                CK_THEME: bool(isDark()),
+                CK_THEME: self._default_dark,
                 CK_DEST_FOLDER: get_default_download_path(),
                 CK_PLAYLIST: False,
                 CK_INDICES: False,

--- a/main.py
+++ b/main.py
@@ -1,10 +1,37 @@
 import argparse
 import logging
+import platform
+import sys
 import warnings
 
 from videodl_logger import videodl_logger
 
 warnings.filterwarnings("ignore", message="urllib3.*doesn't match a supported version")
+
+
+def _patch_mac_ver() -> None:
+    """Give platform.mac_ver() a real version string on macOS.
+
+    Python 3.14's mac_ver() returns '' on macOS 26, and darkdetect (and anything
+    else that parses the version) then does int('') and crashes the whole GUI at
+    import. sw_vers reports the real version regardless of the interpreter bug, so
+    fill the gap from it. A no-op when mac_ver() already works.
+    """
+    if sys.platform != "darwin" or platform.mac_ver()[0]:
+        return
+    import subprocess
+
+    try:
+        version = subprocess.run(
+            ["sw_vers", "-productVersion"], capture_output=True, text=True, timeout=5
+        ).stdout.strip()
+    except Exception:
+        return
+    if version:
+        platform.mac_ver = lambda: (version, ("", "", ""), platform.machine())
+
+
+_patch_mac_ver()
 
 
 # yt-dlp imports these lazily, inside try/except ImportError, and degrades

--- a/main.py
+++ b/main.py
@@ -111,6 +111,15 @@ def main():
 
     app_has_been_updated = check_for_updates()
     if not app_has_been_updated:
+        # On macOS, point Flet at the icon-patched bundle before the first window
+        # opens. init_paths() below can open the aria2 install progress window, and
+        # without this it would carry Flet's default icon instead of video-dl's.
+        # Idempotent: videodl_gui() calls it again and it returns early.
+        if sys.platform == "darwin":
+            from gui.app import _patch_flet_macos_bundle
+
+            _patch_flet_macos_bundle()
+
         logger.debug("Initializing binary paths")
         from sys_vars import init_paths
 

--- a/main.py
+++ b/main.py
@@ -50,14 +50,13 @@ def selftest() -> None:
     release. Paths are deliberately not initialized: that would try to download
     ffmpeg on a bare runner.
     """
-    import flet  # noqa: F401
-    import tufup  # noqa: F401
-
     # Loads the C extension behind XML/plist parsing. On macOS it links libexpat,
     # which the build repoints at a bundled copy; import it here so a broken repoint
     # fails CI instead of crashing a user the first time the app reads a plist.
     import plistlib  # noqa: F401
 
+    import flet  # noqa: F401
+    import tufup  # noqa: F401
     from yt_dlp.dependencies import available_dependencies
     from yt_dlp.version import __version__ as yt_dlp_version
 

--- a/main.py
+++ b/main.py
@@ -52,6 +52,12 @@ def selftest() -> None:
     """
     import flet  # noqa: F401
     import tufup  # noqa: F401
+
+    # Loads the C extension behind XML/plist parsing. On macOS it links libexpat,
+    # which the build repoints at a bundled copy; import it here so a broken repoint
+    # fails CI instead of crashing a user the first time the app reads a plist.
+    import plistlib  # noqa: F401
+
     from yt_dlp.dependencies import available_dependencies
     from yt_dlp.version import __version__ as yt_dlp_version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,10 @@ dependencies = [
 
 [project.optional-dependencies]
 desktop = [
-    "darkdetect",
     "flet-desktop==0.81.0",
     "tufup>=0.10",
 ]
 dev = [
-    "darkdetect",
     "flet-desktop==0.81.0",
     "mypy",
     "Pillow",

--- a/specs/macos-entitlements.plist
+++ b/specs/macos-entitlements.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened runtime is mandatory for notarization, and a PyInstaller app dies on
+  launch under it without these four. The Python interpreter maps writable-then-
+  executable memory (allow-unsigned-executable-memory), the bootloader loads
+  dylibs Apple never signed (disable-library-validation) and sets DYLD_ vars to
+  find them (allow-dyld-environment-variables), and CPython's ctypes/JIT paths
+  want allow-jit. Drop one and the app notarizes clean but crashes for the user.
+-->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/notarize.sh
+++ b/tools/notarize.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Submit a file to Apple's notary service and wait for the verdict, surviving the
+# two things that make `notarytool submit --wait` fragile: transient network
+# errors on a poll (it aborts and throws away however long it already waited) and
+# Apple backlogs that leave a submission "In Progress" for the better part of an
+# hour. Submit once, then poll on our own loop that shrugs off a dropped request.
+#
+# Env: NOTARY_KEY (path to the .p8), MACOS_NOTARY_KEY_ID, MACOS_NOTARY_ISSUER
+# Usage: notarize.sh <file-to-submit>
+set -euo pipefail
+
+FILE=$1
+creds=(--key "$NOTARY_KEY" --key-id "$MACOS_NOTARY_KEY_ID" --issuer "$MACOS_NOTARY_ISSUER")
+
+id=$(xcrun notarytool submit "$FILE" "${creds[@]}" --output-format json \
+  | python3 -c 'import sys, json; print(json.load(sys.stdin)["id"])')
+echo "Notarization submitted: $FILE -> $id"
+
+# 90 minutes: Apple's backlogs run long, but a submission still "In Progress" past
+# that is a service incident to wait out on a re-run, not something to block on.
+deadline=$(( $(date +%s) + 5400 ))
+while :; do
+  # 2>/dev/null so a network blip yields empty output, parsed as "Unreachable"
+  # below, rather than killing the script under `set -e`.
+  status=$(xcrun notarytool info "$id" "${creds[@]}" --output-format json 2>/dev/null \
+    | python3 -c 'import sys, json
+try:
+    print(json.load(sys.stdin).get("status", "Unknown"))
+except Exception:
+    print("Unreachable")')
+  echo "  $id: $status"
+  case "$status" in
+    Accepted) exit 0 ;;
+    Invalid|Rejected)
+      xcrun notarytool log "$id" "${creds[@]}" || true
+      exit 1 ;;
+  esac
+  if [ "$(date +%s)" -gt "$deadline" ]; then
+    echo "::error::notarization unresolved after 90 min (Apple backlog); submission $id still $status"
+    exit 1
+  fi
+  sleep 30
+done

--- a/utils/aria2_install.py
+++ b/utils/aria2_install.py
@@ -137,6 +137,10 @@ def aria2c_progress_page(page: ft.Page) -> None:
             page.update()
         finally:
             time.sleep(1)
-            page.window.destroy()
+            # window.close() is a coroutine in Flet 0.81; calling it bare from this
+            # worker thread never ran, so the window stayed open and ft.run() never
+            # returned — the app hung after "Installation complete!". Schedule it on
+            # the page's event loop instead.
+            page.run_task(page.window.close)
 
     threading.Thread(target=install, daemon=True).start()

--- a/utils/ffmpeg_install.py
+++ b/utils/ffmpeg_install.py
@@ -137,9 +137,12 @@ _FFMPEG_MISSING: dict[str, _FfmpegMissingInfo] = {
         "url": "[Open an issue on GitHub](https://github.com/Kenshin9977/video-dl/issues)",
     },
     "Darwin": {
-        "width": 344,
-        "message": "FFmpeg is missing. On MacOS you can follow this guide to install it:",
-        "url": "[Install FFmpeg](https://macappstore.org/ffmpeg/)",
+        "width": 460,
+        "message": (
+            "FFmpeg is missing or won't run. A Homebrew update can leave it broken; "
+            "install or repair it from a terminal with:  brew reinstall ffmpeg"
+        ),
+        "url": "[Get Homebrew](https://brew.sh)",
     },
     "Linux": {
         "width": 344,

--- a/utils/ffmpeg_install.py
+++ b/utils/ffmpeg_install.py
@@ -92,7 +92,9 @@ def ffmpeg_progress_page(page: ft.Page) -> None:
         except Exception as e:
             logger.error(f"FFmpeg installation error: {e}")
         finally:
-            page.window.destroy()
+            # Coroutine in Flet 0.81, so schedule it rather than calling it bare from
+            # this worker thread, where it would never run and hang the app.
+            page.run_task(page.window.close)
 
     def download_ffmpeg(bits_archi: str, download_folder) -> str:
         api_url = "https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases/latest"

--- a/utils/quickjs_install.py
+++ b/utils/quickjs_install.py
@@ -88,7 +88,9 @@ def quickjs_progress_page(page: ft.Page) -> None:
         except Exception as e:
             logger.error(f"QuickJS installation error: {e}")
         finally:
-            page.window.destroy()
+            # Coroutine in Flet 0.81, so schedule it rather than calling it bare from
+            # this worker thread, where it would never run and hang the app.
+            page.run_task(page.window.close)
 
     def download_quickjs(platform_tag: str, download_folder) -> str:
         try:

--- a/utils/sys_utils.py
+++ b/utils/sys_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 import subprocess
@@ -199,35 +200,31 @@ def get_aria2c_path() -> str | None:
     """
     ext = _get_extension_for_platform()
     aria2c_name = f"aria2c{ext}"
-
-    # Check our install folder first
     install_folder = get_aria2c_install_folder()
     aria2c_path = os.path.join(install_folder, aria2c_name)
-    if Path(aria2c_path).exists():
-        return _aria2c_if_runnable(aria2c_path)
 
-    # Auto-download from fork
-    logger.info("aria2c not found, downloading from Kenshin9977/aria2...")
+    # A cached binary that no longer runs (an older release linked to libraries the
+    # user turned out not to have) is deleted, not kept: fall through and re-download
+    # the current release, so an app that ships a fixed aria2c heals itself instead of
+    # leaving the user stuck on the fallback with the old broken binary in place.
+    if Path(aria2c_path).exists():
+        if _runs_ok(aria2c_path, "--version"):
+            logger.info(f"aria2c found at {aria2c_path}")
+            return aria2c_path
+        logger.warning(f"cached aria2c at {aria2c_path} won't run; re-downloading")
+        with contextlib.suppress(OSError):
+            os.remove(aria2c_path)
+
+    logger.info("Downloading aria2c from Kenshin9977/aria2...")
     ft.run(aria2c_progress_page)
 
-    if Path(aria2c_path).exists():
-        return _aria2c_if_runnable(aria2c_path)
-
-    logger.warning("aria2c installation failed, continuing without it")
-    return None
-
-
-def _aria2c_if_runnable(aria2c_path: str) -> str | None:
-    """aria2c is only an accelerator, so a broken one must not break downloads.
-
-    The binary links Homebrew libs, and a version bump can leave it aborting on
-    launch. If it won't run, return None so the app falls back to yt-dlp's native
-    downloader instead of handing yt-dlp a binary that dies mid-download.
-    """
-    if _runs_ok(aria2c_path, "--version"):
-        logger.info(f"aria2c found at {aria2c_path}")
+    if Path(aria2c_path).exists() and _runs_ok(aria2c_path, "--version"):
+        logger.info(f"aria2c installed at {aria2c_path}")
         return aria2c_path
-    logger.warning(f"aria2c at {aria2c_path} won't run; falling back to yt-dlp's native downloader")
+
+    # aria2c is only a download accelerator, so its absence is a soft failure: the
+    # app runs on yt-dlp's native downloader.
+    logger.warning("aria2c unavailable; falling back to yt-dlp's native downloader")
     return None
 
 

--- a/utils/sys_utils.py
+++ b/utils/sys_utils.py
@@ -85,11 +85,15 @@ def get_ff(ffmpeg_name, ffprobe_name):
         ff_missing_function = ffmpeg_missing_on_mac
 
     ffmpeg_path = _find_executable(ffmpeg_name)
-    if ffmpeg_path:
+    if ffmpeg_path and _runs_ok(ffmpeg_path, "-version"):
         ffprobe_path = _find_executable(ffprobe_name) or ffprobe_name
         logger.info(f"FFmpeg found at {ffmpeg_path}")
         return {"ffmpeg": ffmpeg_path, "ffprobe": ffprobe_path}
 
+    if ffmpeg_path:
+        # Present but won't launch — yt-dlp would just report "ffmpeg is not
+        # installed" with no hint. The dialog tells the user to reinstall it.
+        logger.error(f"FFmpeg at {ffmpeg_path} is present but fails to run (broken dependency?)")
     ft.run(ff_missing_function)
     sys.exit(-1)
 
@@ -110,6 +114,21 @@ def _find_executable(name):
             return candidate
 
     return None
+
+
+def _runs_ok(path, *args, timeout=15) -> bool:
+    """True if the binary at `path` actually runs and exits cleanly.
+
+    Existence is not enough on macOS: a tool whose dynamic dependency was upgraded
+    out from under it — Homebrew's ffmpeg after an x265 bump, our downloaded aria2c
+    after a libxml2 bump — is still a valid executable file that the dynamic linker
+    aborts the instant it launches (a negative return code). Only a clean exit
+    proves it will work when yt-dlp shells out to it.
+    """
+    try:
+        return subprocess.run([path, *args], capture_output=True, timeout=timeout).returncode == 0
+    except Exception:
+        return False
 
 
 def get_quickjs_path() -> str | None:
@@ -185,18 +204,30 @@ def get_aria2c_path() -> str | None:
     install_folder = get_aria2c_install_folder()
     aria2c_path = os.path.join(install_folder, aria2c_name)
     if Path(aria2c_path).exists():
-        logger.info(f"aria2c found at {aria2c_path}")
-        return aria2c_path
+        return _aria2c_if_runnable(aria2c_path)
 
     # Auto-download from fork
     logger.info("aria2c not found, downloading from Kenshin9977/aria2...")
     ft.run(aria2c_progress_page)
 
     if Path(aria2c_path).exists():
-        logger.info(f"aria2c installed at {aria2c_path}")
-        return aria2c_path
+        return _aria2c_if_runnable(aria2c_path)
 
     logger.warning("aria2c installation failed, continuing without it")
+    return None
+
+
+def _aria2c_if_runnable(aria2c_path: str) -> str | None:
+    """aria2c is only an accelerator, so a broken one must not break downloads.
+
+    The binary links Homebrew libs, and a version bump can leave it aborting on
+    launch. If it won't run, return None so the app falls back to yt-dlp's native
+    downloader instead of handing yt-dlp a binary that dies mid-download.
+    """
+    if _runs_ok(aria2c_path, "--version"):
+        logger.info(f"aria2c found at {aria2c_path}")
+        return aria2c_path
+    logger.warning(f"aria2c at {aria2c_path} won't run; falling back to yt-dlp's native downloader")
     return None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -393,15 +393,6 @@ wheels = [
 ]
 
 [[package]]
-name = "darkdetect"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/77/7575be73bf12dee231d0c6e60ce7fb7a7be4fcd58823374fc59a6e48262e/darkdetect-0.8.0.tar.gz", hash = "sha256:b5428e1170263eb5dea44c25dc3895edd75e6f52300986353cd63533fe7df8b1", size = 7681, upload-time = "2022-12-16T14:14:42.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/f2/728f041460f1b9739b85ee23b45fa5a505962ea11fd85bdbe2a02b021373/darkdetect-0.8.0-py3-none-any.whl", hash = "sha256:a7509ccf517eaad92b31c214f593dbcf138ea8a43b2935406bbd565e15527a85", size = 8955, upload-time = "2022-12-16T14:14:40.92Z" },
-]
-
-[[package]]
 name = "flet"
 version = "0.81.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1105,12 +1096,10 @@ dependencies = [
 
 [package.optional-dependencies]
 desktop = [
-    { name = "darkdetect" },
     { name = "flet-desktop" },
     { name = "tufup" },
 ]
 dev = [
-    { name = "darkdetect" },
     { name = "flet-desktop" },
     { name = "mypy" },
     { name = "pillow" },
@@ -1123,8 +1112,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "darkdetect", marker = "extra == 'desktop'" },
-    { name = "darkdetect", marker = "extra == 'dev'" },
     { name = "flet", specifier = "==0.81.0" },
     { name = "flet-desktop", marker = "extra == 'desktop'", specifier = "==0.81.0" },
     { name = "flet-desktop", marker = "extra == 'dev'", specifier = "==0.81.0" },


### PR DESCRIPTION
The `.app` was built unsigned (`codesign_identity=None`) and the DMG was raw `hdiutil` output, so Gatekeeper met every macOS user with *"video-dl is damaged"* or *"unidentified developer"* — the equivalent of the Play Protect warning, but a hard block. Developer ID + notarization is the non-App-Store path that clears it completely, and unlike Android's reputation warning it goes away for good.

**What runs.** In the macOS build job, guarded on `MACOS_CERT_P12` and skipping non-fatally when it is absent (a fork still builds green, just unsigned, like the Windows signing):

1. Import the Developer ID cert into an ephemeral keychain.
2. Sign the `.app` inner-out — every Mach-O with the hardened runtime, deepest first — with the entitlements on the main executable and bundle.
3. Notarize the zipped app, staple the ticket to the `.app`.
4. Build the DMG from the stapled app.
5. Sign, notarize and staple the DMG.
6. `spctl --assess` — Gatekeeper's own verdict gates the release.

All before the artifact is uploaded, so the tufup `sign` job hashes signed bytes — the same ordering constraint the Windows signing already follows.

**The one real risk** is the hardened runtime: a PyInstaller app notarizes clean but crashes on launch without `allow-unsigned-executable-memory`, `disable-library-validation`, `allow-dyld-environment-variables` and `allow-jit`. `specs/macos-entitlements.plist` carries all four with the reason for each. This is why it wants a dry-run before merge: with the secrets set, a `workflow_dispatch` on this branch builds and signs but stops before publishing (the tag guard from #45), producing a signed DMG to actually open and test.

Secrets it needs: `MACOS_CERT_P12`, `MACOS_CERT_PASSWORD`, `MACOS_NOTARY_KEY`, `MACOS_NOTARY_KEY_ID`, `MACOS_NOTARY_ISSUER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)