### PR TITLE
Fix the aria2c startup dialogs and add a Windows installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,6 +272,49 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+      # A bare portable exe leaves a non-technical user with a file in Downloads and
+      # no shortcut, not knowing how to launch it. The installer gives them a Start
+      # Menu and desktop entry. It is a first-run convenience only: it installs to a
+      # per-user location tufup can write to, and updates still happen in place, so
+      # the installer is never part of the tufup update channel.
+      #
+      # It wraps the already-signed portable exe, so this must run after signing.
+      # root.json is installed next to the exe because the onefile build keeps it
+      # inside the archive, where the updater cannot find it to bootstrap trust.
+      - name: Build the Windows installer
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          choco install innosetup --no-progress -y
+          mkdir -p installer_build
+          cp "${{ matrix.artifact }}" installer_build/video-dl.exe
+          cp root.json icon.ico installer_build/
+          version=$(python -c "import version; print(version.__version__)")
+          # Leading // survives MSYS path mangling as a single / to ISCC. pwd -W gives
+          # a native C:/... path so Inno resolves SourceDir on Windows.
+          "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" \
+            "//DAppVersion=$version" \
+            "//DSourceDir=$(pwd -W)/installer_build" \
+            installer/video-dl.iss
+          mv installer_build/video-dl-windows-setup.exe .
+
+      - name: Sign the Windows installer
+        if: runner.os == 'Windows' && env.SIGN_SSH_HOST != ''
+        uses: Kenshin9977/Discord-Overlay/.github/actions/sign-windows@sign-windows-v1
+        with:
+          files: video-dl-windows-setup.exe
+          ssh-host: ${{ secrets.SIGN_SSH_HOST }}
+          ssh-key: ${{ secrets.SIGN_SSH_KEY }}
+          known-hosts: ${{ secrets.SIGN_SSH_KNOWN_HOSTS }}
+
+      - name: Upload the installer
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: video-dl-windows-setup.exe
+          path: video-dl-windows-setup.exe
+
   android:
     runs-on: ubuntu-latest
     env:
@@ -615,7 +658,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p binaries tufup
-          for binary in video-dl-windows.exe video-dl-linux video-dl-macos.dmg video-dl-arm64-v8a.apk; do
+          for binary in video-dl-windows.exe video-dl-windows-setup.exe video-dl-linux video-dl-macos.dmg video-dl-arm64-v8a.apk; do
             mv "artifacts/$binary" binaries/
           done
           mv artifacts/* tufup/
@@ -632,7 +675,9 @@ jobs:
 
             | Windows | macOS | Linux | Android (ARM64) |
             |:-------:|:-----:|:-----:|:---------------:|
-            | [video-dl-windows.exe](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-windows.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-linux) | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-arm64-v8a.apk) |
+            | [Installer](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-windows-setup.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-linux) | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-arm64-v8a.apk) |
+
+            On Windows the installer creates Start Menu and desktop shortcuts. The [portable exe](https://github.com/Kenshin9977/video-dl/releases/download/${{ github.ref_name }}/video-dl-windows.exe) is also available for those who prefer it.
 
             <details>
             <summary>Auto-update files (internal)</summary>

--- a/deps.py
+++ b/deps.py
@@ -42,7 +42,7 @@ FFMPEG_ANDROID_ASSET_PATTERN = "*androidarm64-gpl-shared.tar.xz"
 # same tag for both, or the two platforms ship different binaries.
 # Same again: `release-2.0.1` is a version wearing a prefix, and `loose` skipped it.
 # renovate: datasource=github-releases depName=Kenshin9977/aria2 versioning=regex:^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-ARIA2_TAG = "release-2.0.2"
+ARIA2_TAG = "release-2.0.3"
 ARIA2_REPO = "Kenshin9977/aria2"
 
 # QuickJS, compiled from source for Android. Pinned to a commit: the project has no

--- a/installer/video-dl.iss
+++ b/installer/video-dl.iss
@@ -1,0 +1,73 @@
+; Windows installer for video-dl, built with Inno Setup.
+;
+; Per-user install, no administrator rights. It goes to %LOCALAPPDATA%\Programs so
+; the app can update itself in place: tufup rewrites the exe where it sits, and a
+; Program Files install would need elevation it does not have.
+;
+; AppVersion and SourceDir are passed on the command line by the build workflow
+; (iscc /DAppVersion=... /DSourceDir=...), so the version has one source, version.py.
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#ifndef SourceDir
+  #define SourceDir "."
+#endif
+
+#define AppName "video-dl"
+#define AppExe "video-dl.exe"
+#define AppPublisher "Kenshin9977"
+#define AppUrl "https://github.com/Kenshin9977/video-dl"
+
+[Setup]
+; A stable AppId is what lets an installer upgrade a previous install instead of
+; stacking a second copy. Never change it.
+AppId={{6F3A2C41-8B7D-4E29-9C15-video-dl-0001}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppUrl}
+AppSupportURL={#AppUrl}/issues
+DefaultDirName={localappdata}\Programs\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+OutputDir={#SourceDir}
+OutputBaseFilename=video-dl-windows-setup
+SetupIconFile={#SourceDir}\icon.ico
+UninstallDisplayIcon={app}\{#AppExe}
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+; The bundled exe is already Authenticode-signed and is ~75 MB, so re-verifying it
+; on every launch of the installer buys nothing.
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "french"; MessagesFile: "compiler:Languages\French.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Files]
+Source: "{#SourceDir}\video-dl.exe"; DestDir: "{app}"; Flags: ignoreversion
+; root.json is the trust anchor for the auto-updater. In the onefile exe it lives
+; inside the archive, but the updater looks for it next to the exe, so it has to be
+; installed alongside or the update channel never bootstraps.
+Source: "{#SourceDir}\root.json"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+; Directly under Programs, not in a one-app subfolder, so the Start Menu shows a
+; single "video-dl" entry rather than a video-dl folder holding one shortcut.
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExe}"
+Name: "{userdesktop}\{#AppName}"; Filename: "{app}\{#AppExe}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExe}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent
+
+[UninstallDelete]
+; tufup writes updated binaries and its metadata cache next to the exe as the app
+; runs, so an uninstall must clear the whole install dir, not just what was laid down.
+Type: filesandordirs; Name: "{app}"

--- a/main.py
+++ b/main.py
@@ -31,7 +31,32 @@ def _patch_mac_ver() -> None:
         platform.mac_ver = lambda: (version, ("", "", ""), platform.machine())
 
 
+def _silence_windows_loader_dialogs() -> None:
+    """Stop Windows from popping a message box when a child process can't load a DLL.
+
+    aria2c, ffmpeg and qjs are launched as subprocesses. When one is missing a DLL,
+    the Windows loader shows a "code execution cannot proceed" dialog per missing
+    library — the app has no way to catch or dismiss it, and the user just sees a
+    stack of errors on startup. This bit a user with a dynamically-linked aria2c
+    that shipped without its DLLs: _runs_ok() launching it to check it worked was
+    itself what raised the dialogs.
+
+    SetErrorMode with SEM_FAILCRITICALERRORS makes the loader return an error code
+    instead. It is process-wide and inherited by every child, including the ones
+    yt-dlp spawns, so a broken binary now fails quietly and the app falls back.
+    """
+    if sys.platform != "win32":
+        return
+    import ctypes
+
+    SEM_FAILCRITICALERRORS = 0x0001
+    SEM_NOGPFAULTERRORBOX = 0x0002
+    SEM_NOOPENFILEERRORBOX = 0x8000
+    ctypes.windll.kernel32.SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX)
+
+
 _patch_mac_ver()
+_silence_windows_loader_dialogs()
 
 
 # yt-dlp imports these lazily, inside try/except ImportError, and degrades

--- a/tests/test_windows_loader_dialogs.py
+++ b/tests/test_windows_loader_dialogs.py
@@ -1,0 +1,53 @@
+"""A missing DLL in a child process must not pop a Windows dialog.
+
+aria2c, ffmpeg and qjs run as subprocesses. When one cannot load a DLL, the Windows
+loader shows a modal "code execution cannot proceed" box per missing library, and
+the app cannot catch it: the user just gets a stack of errors at startup. A user hit
+exactly this with a dynamically-linked aria2c shipped without its DLLs.
+
+main.py sets SEM_FAILCRITICALERRORS at startup so the loader returns an error code
+instead. These check the call is made, that it is inherited by children, and that it
+is a no-op off Windows.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+import main
+
+
+class TestSilenceWindowsLoaderDialogs:
+    def test_it_is_a_noop_off_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        # Must not touch ctypes (which has no windll off Windows) or raise.
+        main._silence_windows_loader_dialogs()
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="SetErrorMode is Windows only")
+    def test_it_sets_the_fail_critical_errors_flag(self):
+        import ctypes
+
+        SEM_FAILCRITICALERRORS = 0x0001
+        main._silence_windows_loader_dialogs()
+        assert ctypes.windll.kernel32.GetErrorMode() & SEM_FAILCRITICALERRORS
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="SetErrorMode is Windows only")
+    def test_a_child_that_cannot_load_a_dll_fails_with_a_code_not_a_dialog(self, tmp_path):
+        """A .exe importing a DLL that does not exist returns STATUS_DLL_NOT_FOUND.
+
+        Built here rather than reusing aria2c so the test owns its broken binary. The
+        point is that subprocess.run returns instead of blocking on a modal dialog.
+        """
+        import ctypes
+
+        # A tiny PE that imports a nonexistent DLL is awkward to synthesize, so lean on
+        # the loader directly: LoadLibrary of a missing DLL under this error mode must
+        # return 0 (failure) rather than raising a dialog.
+        main._silence_windows_loader_dialogs()
+        handle = ctypes.windll.kernel32.LoadLibraryW("this-dll-does-not-exist-videodl.dll")
+        assert handle == 0
+
+        # And a real subprocess launch of a missing executable returns, never hangs.
+        with pytest.raises((FileNotFoundError, OSError)):
+            subprocess.run([str(tmp_path / "nope.exe")], capture_output=True, timeout=10)

--- a/tests/test_windows_loader_dialogs.py
+++ b/tests/test_windows_loader_dialogs.py
@@ -30,7 +30,7 @@ class TestSilenceWindowsLoaderDialogs:
 
         SEM_FAILCRITICALERRORS = 0x0001
         main._silence_windows_loader_dialogs()
-        assert ctypes.windll.kernel32.GetErrorMode() & SEM_FAILCRITICALERRORS
+        assert ctypes.windll.kernel32.GetErrorMode() & SEM_FAILCRITICALERRORS  # type: ignore[attr-defined]
 
     @pytest.mark.skipif(sys.platform != "win32", reason="SetErrorMode is Windows only")
     def test_a_child_that_cannot_load_a_dll_fails_with_a_code_not_a_dialog(self, tmp_path):
@@ -45,7 +45,7 @@ class TestSilenceWindowsLoaderDialogs:
         # the loader directly: LoadLibrary of a missing DLL under this error mode must
         # return 0 (failure) rather than raising a dialog.
         main._silence_windows_loader_dialogs()
-        handle = ctypes.windll.kernel32.LoadLibraryW("this-dll-does-not-exist-videodl.dll")
+        handle = ctypes.windll.kernel32.LoadLibraryW("this-dll-does-not-exist-videodl.dll")  # type: ignore[attr-defined]
         assert handle == 0
 
         # And a real subprocess launch of a missing executable returns, never hangs.


### PR DESCRIPTION
Two Windows issues reported by users.

## 1. Five or six "missing DLL" dialogs at startup

The aria2c binary from Kenshin9977/aria2 was dynamically linked and shipped as a lone exe, so it depended on ~10 MinGW DLLs the user did not have. Windows pops one loader dialog per missing DLL.

Two fixes, defence in depth:

- **The binary is now fully static** (Kenshin9977/aria2#3, released as `release-2.0.3`; `deps.py` re-pinned). Verified: it runs and imports no MinGW/lib DLLs.
- **The app no longer lets Windows show loader dialogs at all.** `main.py` calls `SetErrorMode(SEM_FAILCRITICALERRORS)` at startup, which is inherited by every child process (aria2c, ffmpeg, qjs, and yt-dlp's own launches). A binary that cannot load now fails with an error code the app handles, instead of a modal box the app cannot catch. This is what actually surfaced the dialogs: `_runs_ok()` launching the broken aria2c to test it was itself raising them.

Even a future broken native binary can no longer put a dialog in front of a user; the app falls back silently.

## 2. No shortcut, users cannot find how to launch it

A bare portable exe lands in Downloads with no Start Menu or desktop entry. A non-technical user reported not knowing how to run it.

New Inno Setup **installer** (`installer/video-dl.iss`, built and signed in the Windows release job):

- Per-user install to `%LOCALAPPDATA%\Programs\video-dl`, no admin. tufup keeps updating the exe in place; the installer is not part of the update channel.
- Start Menu and desktop shortcuts.
- Installs `root.json` next to the exe, which also fixes a latent bug: the onefile build keeps root.json inside the archive, but the updater looks for it beside the exe, so the tufup trust anchor never bootstrapped for the portable exe.
- Clean uninstaller.

The portable exe is still published for anyone who prefers it.

Verified locally end to end: silent install, both shortcuts land in the right place, the installed app launches and bootstraps tufup from the neighbouring root.json, uninstall removes everything.