### PR TITLE
Point the README downloads at the Windows installer

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -15,7 +15,9 @@ Une application de bureau et Android qui pose une fenêtre devant [yt-dlp](https
 
 | Windows | macOS | Linux | Android |
 |:-------:|:-----:|:-----:|:-------:|
-| [video-dl-windows.exe](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-windows.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-linux) | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-arm64-v8a.apk) |
+| [Installeur](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-windows-setup.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-linux) | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-arm64-v8a.apk) |
+
+Sous Windows, l'installeur ajoute des raccourcis dans le menu Démarrer et sur le bureau. Si vous préférez ne rien installer, l'[exe portable](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-windows.exe) fonctionne seul.
 
 Toutes les [versions](https://github.com/Kenshin9977/video-dl/releases) sont ici. L'application se met à jour toute seule : les nouvelles versions sont téléchargées puis vérifiées sur un canal de mise à jour signé.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ A desktop and Android app that puts a window in front of [yt-dlp](https://github
 
 | Windows | macOS | Linux | Android |
 |:-------:|:-----:|:-----:|:-------:|
-| [video-dl-windows.exe](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-windows.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-linux) | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-arm64-v8a.apk) |
+| [Installer](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-windows-setup.exe) | [video-dl-macos.dmg](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-macos.dmg) | [video-dl-linux](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-linux) | [video-dl-arm64-v8a.apk](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-arm64-v8a.apk) |
+
+On Windows the installer adds Start Menu and desktop shortcuts. If you would rather not install, the [portable exe](https://github.com/Kenshin9977/video-dl/releases/latest/download/video-dl-windows.exe) runs on its own.
 
 Every [release](https://github.com/Kenshin9977/video-dl/releases) is here. The app updates itself: new versions are downloaded and verified against a signed update channel.
 


### PR DESCRIPTION
Both READMEs now link the Windows column to the installer (`video-dl-windows-setup.exe`, added in 2.3.9), which creates the Start Menu and desktop shortcuts a user expects, with the portable exe kept as a secondary link for those who prefer it.