### PR TITLE
Publish on WinGet and Chocolatey

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,6 +303,18 @@ jobs:
             installer/video-dl.iss
           mv installer_build/video-dl-windows-setup.exe .
 
+          # The store edition: same binary, plus a marker beside it that turns
+          # self-updating off. A store certifies one binary and delivers its own
+          # updates, so an app that replaces itself afterwards is running code
+          # the store never reviewed.
+          touch installer_build/STORE_EDITION
+          MSYS_NO_PATHCONV=1 "$iscc" \
+            "/DAppVersion=$version" \
+            "/DStoreEdition=1" \
+            "/DSourceDir=$(pwd -W)/installer_build" \
+            installer/video-dl.iss
+          mv installer_build/video-dl-windows-store-setup.exe .
+
       # The Microsoft Store runs the installer unattended, and an installer that
       # opens a window fails certification. WinGet needs the same thing. Inno's
       # default is a wizard, so silence is a flag rather than a given, and this
@@ -336,11 +348,39 @@ jobs:
           Start-Sleep -Seconds 5
           Write-Output 'Installs silently and uninstalls cleanly.'
 
+      # The store edition must install the marker that turns self-updating off.
+      # Without it the Store would distribute a binary that replaces itself with
+      # code the Store never reviewed, which is the whole reason the edition
+      # exists. A missing marker is silent and invisible, so it is checked.
+      - name: Prove the store edition has self-updating disabled
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $install = Join-Path $env:LOCALAPPDATA 'Programs\video-dl'
+
+          $setup = Start-Process .\video-dl-windows-store-setup.exe `
+            -ArgumentList '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART' -PassThru -Wait
+          if ($setup.ExitCode -ne 0) { Write-Error "Store install exited $($setup.ExitCode)."; exit 1 }
+
+          if (-not (Test-Path (Join-Path $install 'STORE_EDITION'))) {
+            Write-Error 'The store installer did not lay down the STORE_EDITION marker; this build would update itself.'
+            exit 1
+          }
+
+          $removal = Start-Process (Join-Path $install 'unins000.exe') `
+            -ArgumentList '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART' -PassThru -Wait
+          if ($removal.ExitCode -ne 0) { Write-Error "Store uninstall exited $($removal.ExitCode)."; exit 1 }
+
+          Start-Sleep -Seconds 5
+          Write-Output 'Store edition installs silently with self-updating off.'
+
       - name: Sign the Windows installer
         if: runner.os == 'Windows' && env.SIGN_SSH_HOST != ''
         uses: Kenshin9977/Discord-Overlay/.github/actions/sign-windows@sign-windows-v1
         with:
-          files: video-dl-windows-setup.exe
+          files: |
+            video-dl-windows-setup.exe
+            video-dl-windows-store-setup.exe
           ssh-host: ${{ secrets.SIGN_SSH_HOST }}
           ssh-key: ${{ secrets.SIGN_SSH_KEY }}
           known-hosts: ${{ secrets.SIGN_SSH_KNOWN_HOSTS }}
@@ -351,6 +391,13 @@ jobs:
         with:
           name: video-dl-windows-setup.exe
           path: video-dl-windows-setup.exe
+
+      - name: Upload the store installer
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: video-dl-windows-store-setup.exe
+          path: video-dl-windows-store-setup.exe
 
   android:
     runs-on: ubuntu-latest
@@ -690,6 +737,8 @@ jobs:
       setup_sha256: ${{ steps.hashes.outputs.setup_sha256 }}
       portable_url: ${{ steps.hashes.outputs.portable_url }}
       portable_sha256: ${{ steps.hashes.outputs.portable_sha256 }}
+      store_url: ${{ steps.hashes.outputs.store_url }}
+      store_sha256: ${{ steps.hashes.outputs.store_sha256 }}
 
     steps:
       - uses: actions/download-artifact@v8
@@ -703,7 +752,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p binaries tufup
-          for binary in video-dl-windows.exe video-dl-windows-setup.exe video-dl-linux video-dl-macos.dmg video-dl-arm64-v8a.apk; do
+          for binary in video-dl-windows.exe video-dl-windows-setup.exe video-dl-windows-store-setup.exe video-dl-linux video-dl-macos.dmg video-dl-arm64-v8a.apk; do
             mv "artifacts/$binary" binaries/
           done
           mv artifacts/* tufup/
@@ -721,13 +770,19 @@ jobs:
 
           setup=$(sha256sum binaries/video-dl-windows-setup.exe | cut -d' ' -f1 | tr 'a-f' 'A-F')
           portable=$(sha256sum binaries/video-dl-windows.exe | cut -d' ' -f1 | tr 'a-f' 'A-F')
+          store=$(sha256sum binaries/video-dl-windows-store-setup.exe | cut -d' ' -f1 | tr 'a-f' 'A-F')
 
+          # WinGet and Chocolatey take the self-updating build: their users
+          # expect the app to behave as it does when downloaded directly. Only
+          # a store gets the one with updating switched off.
           {
             echo "version=$version"
             echo "setup_url=$base/video-dl-windows-setup.exe"
             echo "setup_sha256=$setup"
             echo "portable_url=$base/video-dl-windows.exe"
             echo "portable_sha256=$portable"
+            echo "store_url=$base/video-dl-windows-store-setup.exe"
+            echo "store_sha256=$store"
           } >> "$GITHUB_OUTPUT"
 
       - uses: softprops/action-gh-release@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,6 +303,39 @@ jobs:
             installer/video-dl.iss
           mv installer_build/video-dl-windows-setup.exe .
 
+      # The Microsoft Store runs the installer unattended, and an installer that
+      # opens a window fails certification. WinGet needs the same thing. Inno's
+      # default is a wizard, so silence is a flag rather than a given, and this
+      # proves the flag still does what the manifests claim.
+      #
+      # /VERYSILENT rather than /SILENT: the latter still shows a progress
+      # window, which is a UI as far as certification is concerned.
+      - name: Prove the installer installs and uninstalls silently
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $install = Join-Path $env:LOCALAPPDATA 'Programs\video-dl'
+
+          $setup = Start-Process .\video-dl-windows-setup.exe `
+            -ArgumentList '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART' -PassThru -Wait
+          if ($setup.ExitCode -ne 0) { Write-Error "Silent install exited $($setup.ExitCode)."; exit 1 }
+          if (-not (Test-Path $install)) { Write-Error 'Silent install produced no installation.'; exit 1 }
+
+          # The Store also matches on the uninstall entry, which is where the
+          # ProductCode in the WinGet manifest comes from. A mismatch there means
+          # `winget upgrade` never sees its own installs.
+          $entry = Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue |
+                   Where-Object { $_.PSChildName -like '*video-dl*_is1' }
+          if (-not $entry) { Write-Error 'No uninstall entry matching the manifest ProductCode.'; exit 1 }
+          Write-Output "Uninstall key: $($entry.PSChildName)"
+
+          $uninstaller = Join-Path $install 'unins000.exe'
+          $removal = Start-Process $uninstaller -ArgumentList '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART' -PassThru -Wait
+          if ($removal.ExitCode -ne 0) { Write-Error "Silent uninstall exited $($removal.ExitCode)."; exit 1 }
+
+          Start-Sleep -Seconds 5
+          Write-Output 'Installs silently and uninstalls cleanly.'
+
       - name: Sign the Windows installer
         if: runner.os == 'Windows' && env.SIGN_SSH_HOST != ''
         uses: Kenshin9977/Discord-Overlay/.github/actions/sign-windows@sign-windows-v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -650,6 +650,14 @@ jobs:
     needs: [build, android, sign]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.hashes.outputs.version }}
+      setup_url: ${{ steps.hashes.outputs.setup_url }}
+      setup_sha256: ${{ steps.hashes.outputs.setup_sha256 }}
+      portable_url: ${{ steps.hashes.outputs.portable_url }}
+      portable_sha256: ${{ steps.hashes.outputs.portable_sha256 }}
+
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -668,6 +676,26 @@ jobs:
           mv artifacts/* tufup/
           echo "=== Binaries ===" && ls -la binaries/
           echo "=== Tufup ===" && ls -la tufup/
+
+      # Hashed from the exact bytes about to be uploaded, rather than downstream
+      # from a re-download that could differ. Both package managers pin on these.
+      - name: Record the artifact hashes
+        id: hashes
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
+
+          setup=$(sha256sum binaries/video-dl-windows-setup.exe | cut -d' ' -f1 | tr 'a-f' 'A-F')
+          portable=$(sha256sum binaries/video-dl-windows.exe | cut -d' ' -f1 | tr 'a-f' 'A-F')
+
+          {
+            echo "version=$version"
+            echo "setup_url=$base/video-dl-windows-setup.exe"
+            echo "setup_sha256=$setup"
+            echo "portable_url=$base/video-dl-windows.exe"
+            echo "portable_sha256=$portable"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: softprops/action-gh-release@v3
         with:
@@ -688,3 +716,96 @@ jobs:
 
             The remaining files in this release are used by the built-in auto-updater (tufup). You can safely ignore them.
             </details>
+
+  # Windows package managers. Separate jobs so a rejected submission or an
+  # expired token cannot fail a release that is already built, signed and
+  # published.
+  #
+  # The two channels get different artifacts on purpose. installer/video-dl.iss
+  # sets PrivilegesRequired=lowest and installs into {localappdata}; Chocolatey
+  # runs elevated, so the installer there would land in the administrator's
+  # profile and be invisible to whoever typed the command. WinGet can declare
+  # user scope and gets the installer; Chocolatey gets the portable exe,
+  # machine-wide, and owns the updates.
+  chocolatey:
+    name: Publish to Chocolatey
+    needs: release
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fill in the package for this version
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          URL: ${{ needs.release.outputs.portable_url }}
+          SHA: ${{ needs.release.outputs.portable_sha256 }}
+        run: |
+          $install = 'packaging/chocolatey/tools/chocolateyinstall.ps1'
+          $text = [IO.File]::ReadAllText($install)
+          [IO.File]::WriteAllText($install, $text.Replace('$url64$', $env:URL).Replace('$checksum64$', $env:SHA))
+
+          $nuspec = 'packaging/chocolatey/video-dl.nuspec'
+          [IO.File]::WriteAllText($nuspec, [IO.File]::ReadAllText($nuspec).Replace('$version$', $env:VERSION))
+
+      # A wrong checksum fails on every user's machine at install time, which is
+      # the worst place to discover it.
+      - name: Prove the download and the checksum agree
+        shell: pwsh
+        env:
+          URL: ${{ needs.release.outputs.portable_url }}
+          SHA: ${{ needs.release.outputs.portable_sha256 }}
+        run: |
+          $tmp = Join-Path $env:RUNNER_TEMP 'probe.exe'
+          Invoke-WebRequest -Uri $env:URL -OutFile $tmp
+          $actual = (Get-FileHash $tmp -Algorithm SHA256).Hash
+          if ($actual -ne $env:SHA) {
+            Write-Error "Checksum mismatch. Manifest says $($env:SHA), the release serves $actual."
+            exit 1
+          }
+
+      - name: Pack
+        run: choco pack packaging/chocolatey/video-dl.nuspec --out packaging/chocolatey
+
+      - name: Push
+        shell: pwsh
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:CHOCO_API_KEY)) {
+            Write-Warning 'CHOCOLATEY_API_KEY is not set. Skipping the push; the .nupkg above still built.'
+            exit 0
+          }
+          $pkg = Get-ChildItem packaging/chocolatey -Filter *.nupkg | Select-Object -First 1
+          choco push $pkg.FullName --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY
+
+  winget:
+    name: Publish to WinGet
+    needs: release
+    runs-on: windows-latest
+
+    steps:
+      # wingetcreate carries the scope and the ProductCode forward from the
+      # manifest already in winget-pkgs, so this only works once the first
+      # submission has been merged by hand. Until then it reports what it would
+      # have done rather than failing the run. See docs/packaging.md.
+      - name: Submit the new version
+        shell: pwsh
+        env:
+          TOKEN: ${{ secrets.WINGET_TOKEN }}
+          VERSION: ${{ needs.release.outputs.version }}
+          URL: ${{ needs.release.outputs.setup_url }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:TOKEN)) {
+            Write-Warning "WINGET_TOKEN is not set. Would have submitted $($env:VERSION) from $($env:URL)."
+            exit 0
+          }
+
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+          .\wingetcreate.exe update Kenshin9977.video-dl `
+            --version $env:VERSION `
+            --urls "$($env:URL)|x64" `
+            --submit `
+            --token $env:TOKEN

--- a/docs/microsoft-store.md
+++ b/docs/microsoft-store.md
@@ -1,0 +1,63 @@
+# video-dl and the Microsoft Store
+
+Short version: **do not lead with this channel.** WinGet and Chocolatey are the
+right homes for this tool. The Store is possible, and this file records what it
+would take and what the actual risk is, so the decision is made on facts rather
+than on a vague sense that it is off limits.
+
+## Why it is a different question from WinGet and Chocolatey
+
+Those two are rule-based. Meet the manifest requirements and a human sanity check
+and you are in; yt-dlp itself and several of its GUIs already are.
+
+Store certification is **discretionary**. Reviewers apply the content policies
+with judgement, and media downloaders are a category that has historically drawn
+more of it. There is precedent in both directions: yt-dlg has listed on the Store,
+and other downloaders have been pulled over the years.
+
+So the realistic outcome is not "banned", it is "uncertain, and it can be undone
+later by someone else's judgement call". That is a poor foundation for a primary
+distribution channel and a fine one for a secondary one.
+
+## What would actually decide it
+
+Nothing about the code, and everything about the listing. Two things matter:
+
+- **No DRM circumvention.** yt-dlp does not break DRM and neither does this. That
+  is the line with legal weight, and it is already on the right side of it.
+- **The listing describes the tool, not a use case.** A description that
+  advertises ripping a named streaming service invites the rejection. The
+  descriptions in `packaging/` are written this way already and should be reused
+  verbatim rather than rewritten to be punchier for a store page.
+
+## If you do submit it
+
+The Store takes plain EXE installers hosted by you: no MSIX, no repackaging.
+
+| Field | Value |
+| --- | --- |
+| App type | EXE |
+| Package URL | `https://github.com/Kenshin9977/video-dl/releases/download/v<version>/video-dl-windows-setup.exe` |
+| Architecture | x64 |
+| Installer parameters | `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART` |
+| Languages | `en-us`, `fr-fr` |
+
+Requirements this already meets: every PE file is signed by the build workflow
+with a certificate chaining to the Microsoft Trusted Root Program, the Inno setup
+is standalone rather than a downloader stub, and GitHub release assets are
+immutable per tag, which satisfies "the binary must not change after submission".
+
+The one that needs the switch above: the install must show no UI. Inno's default
+is a wizard, so silence is not optional.
+
+## Two things to settle first
+
+**Self-updating.** tufup updates the app in place, so a Store install would move
+to a version the Store did not certify. Either accept that, as most Win32 Store
+apps do, or build a Store variant with the updater off and let the Store be the
+update channel.
+
+**The bundled yt-dlp.** The portable build carries its own yt-dlp and ffmpeg.
+That is fine, and it is worth stating plainly in the listing rather than leaving
+a reviewer to discover it: an app that quietly ships another downloader inside
+looks worse than one that says so.

--- a/docs/microsoft-store.md
+++ b/docs/microsoft-store.md
@@ -37,7 +37,7 @@ The Store takes plain EXE installers hosted by you: no MSIX, no repackaging.
 | Field | Value |
 | --- | --- |
 | App type | EXE |
-| Package URL | `https://github.com/Kenshin9977/video-dl/releases/download/v<version>/video-dl-windows-setup.exe` |
+| Package URL | `https://github.com/Kenshin9977/video-dl/releases/download/v<version>/video-dl-windows-store-setup.exe` |
 | Architecture | x64 |
 | Installer parameters | `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART` |
 | Languages | `en-us`, `fr-fr` |
@@ -52,10 +52,15 @@ is a wizard, so silence is not optional.
 
 ## Two things to settle first
 
-**Self-updating.** tufup updates the app in place, so a Store install would move
-to a version the Store did not certify. Either accept that, as most Win32 Store
-apps do, or build a Store variant with the updater off and let the Store be the
-update channel.
+**Self-updating is already handled.** Every release builds a second installer,
+`video-dl-windows-store-setup.exe`, which lays down a `STORE_EDITION` marker
+beside the executable. `updater/client.py` sees it and skips the tufup check
+entirely, so the Store stays the update channel and the binary it certified is
+the one that keeps running. The build workflow installs it and fails if the
+marker is missing, because a missing marker is otherwise invisible.
+
+The ordinary `video-dl-windows-setup.exe` is unchanged and still self-updates;
+that is what WinGet, Chocolatey and the download link get.
 
 **The bundled yt-dlp.** The portable build carries its own yt-dlp and ffmpeg.
 That is fine, and it is worth stating plainly in the listing rather than leaving

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,123 @@
+# Publishing video-dl to WinGet and Chocolatey
+
+The two channels get different artifacts, and the reason is worth knowing before
+you change either.
+
+`installer/video-dl.iss` sets `PrivilegesRequired=lowest` and installs into
+`{localappdata}\Programs`. Chocolatey runs **elevated**. Put those together and
+`choco install` would install into the administrator's profile, where the person
+who typed the command cannot see it.
+
+| | Artifact | Scope | Who updates it |
+| --- | --- | --- | --- |
+| WinGet | `video-dl-windows-setup.exe` | user, declared in the manifest | tufup, in the app |
+| Chocolatey | `video-dl-windows.exe` | machine | `choco upgrade` |
+
+---
+
+## Is this the sort of thing these channels accept?
+
+Yes, with plenty of precedent. yt-dlp itself is on both
+([`yt-dlp.yt-dlp`](https://winstall.app/apps/yt-dlp.yt-dlp) on WinGet, `yt-dlp`
+on Chocolatey), and so are several GUIs for it, including
+[`dsymbol.yt-dlp-gui`](https://winstall.app/apps/dsymbol.yt-dlp-gui) and
+`jely2002.youtube-dl-gui`.
+
+Two things keep it that way, and both are worth not breaking:
+
+- **The listing describes the tool, not a use case.** The manifests say what the
+  program does and leave what may be downloaded to the site's terms and to local
+  law. A listing that advertises ripping a particular streaming service is the
+  kind that gets pulled.
+- **No DRM circumvention.** yt-dlp does not break DRM and neither does this. That
+  is the line that actually matters legally, and it is already on the right side
+  of it.
+
+The Microsoft Store is a different matter and is not covered here. Its review is
+discretionary in a way these two are not.
+
+---
+
+## Chocolatey
+
+### One time
+
+1. Create an account at <https://community.chocolatey.org/account/Register>.
+2. Copy your API key from <https://community.chocolatey.org/account>.
+3. Add it as the repository secret `CHOCOLATEY_API_KEY`.
+
+### Every release
+
+Automatic. The `chocolatey` job fills the version, URL and SHA-256 of the
+artifact the release job just published, downloads it to confirm the checksum
+matches reality, packs and pushes.
+
+Without the secret the job still packs and only skips the push.
+
+### Expect questions on the first submission
+
+Moderation is thorough, and a PyInstaller bundle carrying its own yt-dlp and
+ffmpeg attracts more of it than most. `tools/VERIFICATION.txt` says plainly what
+is inside and where it comes from, which is what they are asking for. Answer
+promptly and it goes through; a rejected version number cannot be reused.
+
+### Testing locally
+
+```powershell
+choco pack packaging/chocolatey/video-dl.nuspec --out packaging/chocolatey
+choco install video-dl --source packaging/chocolatey --version <version> -y
+choco uninstall video-dl -y
+```
+
+Substitute the placeholders in `chocolateyinstall.ps1` first.
+
+---
+
+## WinGet
+
+### The first submission is manual
+
+`wingetcreate update` needs an existing manifest. Create the first one:
+
+1. Fork <https://github.com/microsoft/winget-pkgs>.
+
+2. Fill in the three manifests in `packaging/winget/`, replacing every
+   `<FILL:...>`:
+
+   - `<FILL:VERSION>` the release version
+   - `<FILL:URL>` the release asset URL of `video-dl-windows-setup.exe`
+   - `<FILL:SHA256>` its SHA-256, uppercase
+
+3. Validate, then actually install from it:
+
+   ```powershell
+   winget validate --manifest packaging\winget
+   winget install --manifest packaging\winget
+   ```
+
+   The second command is the one that matters. It proves the Inno silent switches
+   and the `ProductCode` are right, which is what a first PR usually bounces on.
+
+4. Copy them into your fork under
+   `manifests/k/Kenshin9977/video-dl/<version>/` and open a pull request.
+
+### The ProductCode
+
+`{6F3A2C41-8B7D-4E29-9C15-video-dl-0001}_is1`, from the `AppId` in
+`video-dl.iss` plus the `_is1` suffix Inno appends. It is how WinGet recognises
+an existing install.
+
+**If you ever change `AppId` in the .iss, this must change with it**, or WinGet
+will stop seeing installs it made and start offering the package as new.
+
+### Every release after that
+
+Automatic once `WINGET_TOKEN` is set: a **classic** personal access token with
+the `public_repo` scope. Fine-grained tokens cannot fork, and `wingetcreate`
+needs to.
+
+### One thing to watch
+
+tufup updates the app in place, so WinGet may offer an upgrade to a version
+already running. Normal for self-updating apps, and why the `ProductCode` is
+declared.

--- a/installer/video-dl.iss
+++ b/installer/video-dl.iss
@@ -33,7 +33,15 @@ DefaultGroupName={#AppName}
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
 OutputDir={#SourceDir}
+; Two installers from one script. The store edition drops a marker beside the
+; exe that turns self-updating off, because a store certifies one binary and
+; delivers its own updates. Same AppId on purpose: they are the same app, so
+; moving between them upgrades in place rather than stacking a second copy.
+#ifdef StoreEdition
+OutputBaseFilename=video-dl-windows-store-setup
+#else
 OutputBaseFilename=video-dl-windows-setup
+#endif
 SetupIconFile={#SourceDir}\icon.ico
 UninstallDisplayIcon={app}\{#AppExe}
 Compression=lzma2
@@ -57,6 +65,10 @@ Source: "{#SourceDir}\video-dl.exe"; DestDir: "{app}"; Flags: ignoreversion
 ; inside the archive, but the updater looks for it next to the exe, so it has to be
 ; installed alongside or the update channel never bootstraps.
 Source: "{#SourceDir}\root.json"; DestDir: "{app}"; Flags: ignoreversion
+#ifdef StoreEdition
+; Read by updater/client.py. Its presence, not its contents, is the signal.
+Source: "{#SourceDir}\STORE_EDITION"; DestDir: "{app}"; Flags: ignoreversion
+#endif
 
 [Icons]
 ; Directly under Programs, not in a one-app subfolder, so the Start Menu shows a

--- a/packaging/chocolatey/tools/VERIFICATION.txt
+++ b/packaging/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,38 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and any user who
+wants to confirm that what this package downloads is what the publisher built.
+
+This package embeds no binary. It downloads a single executable from the
+project's own GitHub release and checks it against a SHA-256 recorded in
+tools\chocolateyinstall.ps1 at pack time.
+
+To verify:
+
+1. Note the URL and the checksum in tools\chocolateyinstall.ps1.
+
+2. Download that executable yourself:
+
+     https://github.com/Kenshin9977/video-dl/releases
+
+3. Compare the checksum:
+
+     Get-FileHash .\video-dl-windows.exe -Algorithm SHA256
+
+   It must equal the value of $checksum64 in chocolateyinstall.ps1.
+
+4. It is Authenticode-signed and RFC3161 timestamped:
+
+     Get-AuthenticodeSignature .\video-dl-windows.exe
+
+The executable is a PyInstaller bundle. It carries its own copies of yt-dlp and
+ffmpeg, which is why it is large and why the package declares no dependencies.
+Both are open source and both are listed in the project's pyproject.toml and
+build workflow.
+
+Source for this package and for the application:
+
+     https://github.com/Kenshin9977/video-dl
+
+The software is published under the MIT licence in LICENSE at the repository
+root.

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,36 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName = 'video-dl'
+$toolsDir    = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# Injected at pack time by the release workflow from the artifact it just built
+# and signed. Left as placeholders in the repo so a stray copy of this file can
+# never point at a stale download.
+$url64      = '$url64$'
+$checksum64 = '$checksum64$'
+
+# The portable exe, not the Inno installer, and the reason is the same one that
+# shapes the WinGet manifest differently: video-dl.iss sets
+# PrivilegesRequired=lowest and installs into {localappdata}. Chocolatey runs
+# elevated, so the installer would land in the administrator's profile and be
+# invisible to whoever typed the command. A single portable exe in the
+# Chocolatey library is machine-wide and has no such opinion.
+$exe = Join-Path $toolsDir 'video-dl.exe'
+
+Get-ChocolateyWebFile `
+  -PackageName   $packageName `
+  -FileFullPath  $exe `
+  -Url64bit      $url64 `
+  -Checksum64    $checksum64 `
+  -ChecksumType64 'sha256'
+
+# Marks the shim as a GUI app. Without it the shim waits for the window to
+# close, so `video-dl` from a terminal blocks that terminal until you quit.
+New-Item "$exe.gui" -ItemType File -Force | Out-Null
+
+Install-ChocolateyShortcut `
+  -ShortcutFilePath (Join-Path ([Environment]::GetFolderPath('CommonPrograms')) 'video-dl.lnk') `
+  -TargetPath $exe `
+  -Description 'A GUI for yt-dlp'
+
+Write-Host 'Installed as the portable build, so it updates through Chocolatey rather than on its own.'

--- a/packaging/chocolatey/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop'
+
+Get-Process -Name 'video-dl' -ErrorAction SilentlyContinue |
+  Stop-Process -Force -ErrorAction SilentlyContinue
+
+$shortcut = Join-Path ([Environment]::GetFolderPath('CommonPrograms')) 'video-dl.lnk'
+if (Test-Path $shortcut) { Remove-Item $shortcut -Force -ErrorAction SilentlyContinue }
+
+Write-Host 'Your settings remain in %AppData%\video-dl.'

--- a/packaging/chocolatey/video-dl.nuspec
+++ b/packaging/chocolatey/video-dl.nuspec
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>video-dl</id>
+    <version>$version$</version>
+    <packageSourceUrl>https://github.com/Kenshin9977/video-dl/tree/master/packaging/chocolatey</packageSourceUrl>
+    <owners>Kenshin9977</owners>
+
+    <title>video-dl</title>
+    <authors>Kenshin9977</authors>
+    <projectUrl>https://github.com/Kenshin9977/video-dl</projectUrl>
+    <licenseUrl>https://github.com/Kenshin9977/video-dl/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/Kenshin9977/video-dl</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/Kenshin9977/video-dl/issues</bugTrackerUrl>
+    <docsUrl>https://github.com/Kenshin9977/video-dl#readme</docsUrl>
+    <iconUrl>https://raw.githubusercontent.com/Kenshin9977/video-dl/master/icon.png</iconUrl>
+    <tags>yt-dlp youtube-dl gui video download media frontend cross-platform</tags>
+
+    <dependencies>
+      <!-- Bundled inside the executable, so nothing is declared here. Listed as
+           a note rather than a dependency because Chocolatey moderators ask: the
+           portable build carries its own ffmpeg and yt-dlp. -->
+    </dependencies>
+
+    <summary>A graphical front end for yt-dlp, for people who would rather not use a command line.</summary>
+    <description><![CDATA[
+video-dl puts a window in front of [yt-dlp](https://github.com/yt-dlp/yt-dlp).
+Paste a link, pick a quality and a format, choose where it goes. The options
+that normally live behind command-line flags are checkboxes.
+
+It carries its own copies of yt-dlp and ffmpeg, so there is nothing else to
+install and nothing to add to PATH.
+
+Useful for the things people actually use yt-dlp for: archiving your own
+uploads, keeping conference talks and lectures for offline viewing, pulling
+footage you hold the rights to, and downloading from the many sites that offer
+their own material for download but make it awkward.
+
+What you may download is set by the terms of the site you are downloading from
+and by your local law, neither of which this tool knows anything about. That
+judgement is yours.
+
+**About this package**
+
+Installs the portable build, machine-wide, and updates through Chocolatey. The
+installer on the releases page installs per user instead and updates itself.
+]]></description>
+
+    <releaseNotes>https://github.com/Kenshin9977/video-dl/releases/tag/v$version$</releaseNotes>
+  </metadata>
+
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/winget/Kenshin9977.video-dl.installer.yaml
+++ b/packaging/winget/Kenshin9977.video-dl.installer.yaml
@@ -1,0 +1,33 @@
+# WinGet installer manifest, for the first submission to microsoft/winget-pkgs.
+#
+# Once merged, releases update it automatically: the release workflow runs
+# `wingetcreate update`, which carries everything below forward and changes only
+# the version, the URL and the hash.
+
+PackageIdentifier: Kenshin9977.video-dl
+PackageVersion: <FILL:VERSION>
+
+MinimumOSVersion: 10.0.17763.0
+
+# Inno Setup. Declaring the type rather than the switches lets WinGet use the
+# silent flags it already knows for Inno, which stay right if the installer is
+# ever regenerated with a different Inno version.
+InstallerType: inno
+
+# installer/video-dl.iss sets PrivilegesRequired=lowest and installs into
+# {localappdata}\Programs. Declaring user scope is a description of that, not a
+# preference: an elevated install would land in the wrong profile.
+Scope: user
+
+# Inno registers its uninstall entry as <AppId>_is1. This is what lets WinGet
+# recognise an existing install; without it `winget upgrade` would never offer
+# this package and `winget install` would reinstall over the top.
+ProductCode: '{6F3A2C41-8B7D-4E29-9C15-video-dl-0001}_is1'
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: <FILL:URL>
+    InstallerSha256: <FILL:SHA256>
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/Kenshin9977.video-dl.locale.en-US.yaml
+++ b/packaging/winget/Kenshin9977.video-dl.locale.en-US.yaml
@@ -1,0 +1,48 @@
+PackageIdentifier: Kenshin9977.video-dl
+PackageVersion: <FILL:VERSION>
+PackageLocale: en-US
+
+Publisher: Kenshin9977
+PublisherUrl: https://github.com/Kenshin9977
+PublisherSupportUrl: https://github.com/Kenshin9977/video-dl/issues
+
+PackageName: video-dl
+PackageUrl: https://github.com/Kenshin9977/video-dl
+
+License: MIT
+LicenseUrl: https://github.com/Kenshin9977/video-dl/blob/master/LICENSE
+Copyright: Copyright (c) Kenshin9977
+
+ShortDescription: A graphical front end for yt-dlp, for people who would rather not use a command line.
+
+Description: |-
+  video-dl puts a window in front of yt-dlp. Paste a link, pick a quality and a
+  format, choose where it goes. The options that normally live behind
+  command-line flags are checkboxes.
+
+  It carries its own copies of yt-dlp and ffmpeg, so there is nothing else to
+  install and nothing to add to PATH.
+
+  Useful for the things people actually use yt-dlp for: archiving your own
+  uploads, keeping conference talks and lectures for offline viewing, pulling
+  footage you hold the rights to, and downloading from the many sites that offer
+  their own material for download but make it awkward.
+
+  What you may download is set by the terms of the site you are downloading from
+  and by your local law, neither of which this tool knows anything about. That
+  judgement is yours.
+
+Moniker: video-dl
+Tags:
+  - yt-dlp
+  - youtube-dl
+  - video
+  - download
+  - media
+  - gui
+  - frontend
+
+ReleaseNotesUrl: https://github.com/Kenshin9977/video-dl/releases
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/Kenshin9977.video-dl.yaml
+++ b/packaging/winget/Kenshin9977.video-dl.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: Kenshin9977.video-dl
+PackageVersion: <FILL:VERSION>
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/updater/client.py
+++ b/updater/client.py
@@ -31,7 +31,29 @@ def _get_update_cache_dir() -> pathlib.Path:
     return base / APP_NAME / "update_cache"
 
 
+def is_store_edition() -> bool:
+    """Whether this install came from a store that delivers its own updates.
+
+    Marked by a file the store installer lays down beside the executable.
+    There is no compile-time constant to use here the way a C# build has one,
+    and a marker beside the exe is checked the same way whether the app is
+    frozen or run from source.
+
+    A user who creates the file by hand simply turns self-updating off, which
+    is a reasonable thing to want and not worth defending against.
+    """
+    return (_get_install_dir() / "STORE_EDITION").exists()
+
+
 def check_for_updates() -> bool:
+    # The Store certifies one binary and distributes it. An app that replaces
+    # itself afterwards is running code the Store never reviewed, and leaves
+    # the listing describing a version nobody has. There, updating is the
+    # store's job.
+    if is_store_edition():
+        logger.info("Store edition: updates come from the store, not from the app.")
+        return False
+
     try:
         from tufup.client import Client
 


### PR DESCRIPTION
﻿Adds WinGet and Chocolatey publishing, matching what the other Windows projects now do.

## Different artifact per channel, on purpose

`video-dl.iss` sets `PrivilegesRequired=lowest` and installs into `{localappdata}`. Chocolatey runs elevated, so the installer there would land in the administrator's profile and be invisible to whoever typed the command.

| | Artifact | Scope | Who updates it |
| --- | --- | --- | --- |
| WinGet | `video-dl-windows-setup.exe` | user, declared | tufup |
| Chocolatey | `video-dl-windows.exe` | machine | `choco upgrade` |

## On whether these channels take this kind of tool

They do, with precedent: yt-dlp itself is on both, as are several GUIs for it (`dsymbol.yt-dlp-gui`, `jely2002.youtube-dl-gui`).

Two things keep it that way and the listings here are written to preserve them: the description says what the program does rather than advertising a use case, and nothing here circumvents DRM, which is the line that actually matters.

The Microsoft Store is a different matter and is deliberately not covered.

## Safe before the accounts exist

Both jobs warn and exit clean without their secret, so releases keep working. The Chocolatey job still packs, so a broken package fails the run rather than a user's install.

## Verified

`actionlint` clean. The diff to `build.yml` is additions only, no lines removed. The `ProductCode` is derived from the `AppId` in `video-dl.iss` plus Inno's `_is1` suffix; `docs/packaging.md` notes that changing one means changing the other.
