### PR TITLE
Make the canary work, and unblock every merge gate

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ytdlp.outputs.version }}
+    # Without this, every `uv run` below re-syncs the environment from uv.lock and
+    # quietly undoes the upgrade, so the canary tests the pinned yt-dlp instead of
+    # the newest one. It did exactly that, greenly, until it was noticed.
+    env:
+      UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Open an issue, or add to the open one
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.latest-ytdlp.outputs.version }}
           RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -32,7 +32,11 @@ pytestmark = [
 # A small, stable, direct http file. Deliberately not YouTube: YouTube blocks
 # datacenter IPs often enough that gating a merge on it would train us to ignore a
 # red CI. The YouTube run is a separate, informational CI step.
-SAMPLE = "https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4"
+#
+# Not Big Buck Bunny any more: blender.org re-hosted that whole directory as .zip in
+# July 2026 and the plain .mp4 started 404ing, which held every merge gate red for
+# seven weeks. This trailer has sat at the same URL since 2010.
+SAMPLE = "https://download.blender.org/durian/trailer/sintel_trailer-480p.mp4"
 
 
 @pytest.fixture


### PR DESCRIPTION
The canary has been red every morning since 2026-07-23. Three separate defects,
none of them yt-dlp.

### The network test downloads a file that no longer exists

`blender.org` re-hosted the Big Buck Bunny directory as `.zip` archives on 22 July
2026. `BigBuckBunny_320x180.mp4` has 404'd ever since, and the canary went from
green on the 22nd to red on the 23rd and stayed there.

`ci.yml`'s `download` job runs the same test, so this is also why the
"Bump yt-dlp to v2026.8.19" pull request is red. The gate that exists to let a
yt-dlp bump merge unattended has been broken for seven weeks. Nothing was wrong
with the bump.

Now points at the Sintel trailer: same host, 4.4 MB, has the audio track
`FFmpegExtractAudio` needs, unmoved since 2010.

### The canary never tested the newest yt-dlp

`uv run` re-syncs the environment from `uv.lock` before running, which undid the
`uv pip install --upgrade` two steps earlier. From today's log:

```
+ yt-dlp==2026.8.19          <- the upgrade
Uninstalled 7 packages       <- uv run, resyncing to the lock
Installed 7 packages
Testing against yt-dlp 2026.07.04
```

Every step ran against the pin. The canary has been a slow duplicate of CI since
it was written, and would have reported green through exactly the upstream break
it was built to catch. `UV_NO_SYNC` at the job level fixes it and leaves the
explicit `uv sync --locked` alone.

### The report job could never open an issue

No checkout in that job, so `gh` shelled out to git for the repo, found nothing,
and exited 1: `failed to run git: fatal: not a git repository`. The `canary`
label it filters on did not exist either, so `gh issue create --label canary`
would have failed a step later.

Forty-seven red runs, zero issues, no notification. `GH_REPO` gives `gh` its
context without a checkout, and the `canary` label now exists in the repo.

### Verified

- Both network tests pass locally against the new URL.
- `ruff check`, `ruff format --check` clean.
- Full suite: 496 passed. One pre-existing unrelated failure,
  `test_lang.py::TestGetLanguage::test_none_locale_defaults_to_english`, which
  mocks `i18n.lang.locale` but leaves a path that reads the real environment, so
  it fails on a French machine and passes on the en_US runners. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5ahxqDR2Gys8nunFso1nh