### PR TITLE
Fix the two failures that only ever show up on a dev machine

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,10 @@ def _patch_mac_ver() -> None:
     else that parses the version) then does int('') and crashes the whole GUI at
     import. sw_vers reports the real version regardless of the interpreter bug, so
     fill the gap from it. A no-op when mac_ver() already works.
+
+    The replacement swallows arguments because the real mac_ver() takes three
+    optional ones. Nothing here passes any, but a stdlib signature is not ours to
+    narrow, and dropping the *_ makes mypy right for the wrong reason.
     """
     if sys.platform != "darwin" or platform.mac_ver()[0]:
         return
@@ -28,7 +32,7 @@ def _patch_mac_ver() -> None:
     except Exception:
         return
     if version:
-        platform.mac_ver = lambda: (version, ("", "", ""), platform.machine())
+        platform.mac_ver = lambda *_: (version, ("", "", ""), platform.machine())
 
 
 _patch_mac_ver()

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from unittest.mock import patch
 
@@ -67,10 +68,21 @@ class TestGetLanguage:
         mock_locale.getlocale.return_value = ("ja_JP", "UTF-8")
         assert _get_language() == Language.english
 
+    # A None locale is not the end of the lookup: _get_language falls through to
+    # LANG and friends, so mocking locale alone leaves the answer up to whoever runs
+    # the test. This asserted english and quietly meant "english, unless your shell
+    # says otherwise" — green on the en_US runners, red on a French machine.
+    @patch.dict(os.environ, {}, clear=True)
     @patch("i18n.lang.locale")
-    def test_none_locale_defaults_to_english(self, mock_locale):
+    def test_none_locale_and_no_env_defaults_to_english(self, mock_locale):
         mock_locale.getlocale.return_value = (None, None)
         assert _get_language() == Language.english
+
+    @patch.dict(os.environ, {"LANG": "de_DE.UTF-8"}, clear=True)
+    @patch("i18n.lang.locale")
+    def test_none_locale_falls_back_to_the_environment(self, mock_locale):
+        mock_locale.getlocale.return_value = (None, None)
+        assert _get_language() == Language.german
 
 
 class TestGetText:


### PR DESCRIPTION
Both of these are red locally on macOS with a French locale and green on the CI
runners, which is why they have survived. Neither is caught by any job today.

### The locale test asks the machine it runs on

`test_none_locale_defaults_to_english` mocked `locale.getlocale()` to `(None, None)`
and asserted english. But `None` is not where `_get_language` stops — it falls
through to `LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`. The assertion actually
meant "english, unless your shell says otherwise": green on the `en_US` runners,
red on any French or German machine.

That is the worst shape a test can take. It fails for whoever is making an
unrelated change and passes for the person reviewing it.

Split in two, both isolated with `patch.dict(os.environ, {}, clear=True)`: one for
the real default, one pinning the env fallback the old test was exercising by
accident and never asserting.

### The mac_ver stand-in dropped the real signature

`platform.mac_ver(release, versioninfo, machine)` takes three optional arguments.
The lambda replacing it on macOS 26 took none, so any caller passing one would
get a `TypeError`. mypy flagged exactly this on darwin — two errors on `main.py:31`
— and CI never saw it: the lint job runs on ubuntu, where `sys.platform != "darwin"`
narrows the branch away and the assignment is never type-checked.

`lambda *_:` fixes the type errors and the latent `TypeError` in one character.
The type errors were pointing at a real defect, not at style.

### Verified, on macOS with LANG=fr_FR

Before: `mypy` 2 errors, `pytest` 1 failed / 496 passed.
After: `mypy` clean over 75 files, `pytest` 498 passed, 1 skipped.

CI going green here proves nothing for either fix — it was already green. The
evidence is that both were red locally and are not any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5ahxqDR2Gys8nunFso1nh